### PR TITLE
For a 0.2.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 ScikitLearn = "3646fa90-6ef7-5e7e-9f22-8aca16db6324"
 
 [compat]
+MLJModelInterface = "1.4"
 PyCall = "1"
 ScikitLearn = "0.5,0.6"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJScikitLearnInterface"
 uuid = "5ae90465-5518-4432-b9d2-8a1def2f0cab"
 authors = ["Thibaut Lienart, Anthony Blaom"]
-version = "0.1.10"
+version = "0.2.0"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ ScikitLearn = "3646fa90-6ef7-5e7e-9f22-8aca16db6324"
 MLJModelInterface = "1.4"
 PyCall = "1"
 ScikitLearn = "0.5,0.6"
-julia = "1"
+julia = "1.6"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 ScikitLearn = "3646fa90-6ef7-5e7e-9f22-8aca16db6324"
 
 [compat]
-MLJModelInterface = "0.3.6,0.4,1"
 PyCall = "1"
 ScikitLearn = "0.5,0.6"
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Repository implementing MLJ interface for
 [ScikitLearn.jl](https://github.com/JuliaStats/ScikitLearn.jl) models.
 
 
-[![Build Status](https://travis-ci.com/alan-turing-institute/MLJScikitLearnInterface.jl.svg?branch=master)](https://travis-ci.com/github/alan-turing-institute/MLJScikitLearnInterface.jl)
-[![Coverage](http://codecov.io/github/alan-turing-institute/MLJScikitLearnInterface.jl/coverage.svg?branch=master)](https://codecov.io/gh/alan-turing-institute/MLJScikitLearnInterface.jl)
+[![Build Status](https://github.com/JuliaAI/MLJScikitLearnInterface.jl/workflows/CI/badge.svg)](https://github.com/JuliaAI/MLJScikitLearnInterface.jl/actions)
+[![Coverage](http://codecov.io/github/JuliaAI/MLJScikitLearnInterface.jl/coverage.svg?branch=master)](https://codecov.io/gh/JuliaAI/MLJScikitLearnInterface.jl)
 
 **Note**: for errors with MKL on Mac, please refer to [ScikitLearn.jl](https://github.com/cstjean/ScikitLearn.jl) as it's a known issue.
 

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -1,19 +1,19 @@
-function descr(T, d)
+function add_human_name_trait(T, d)
     ex = quote
-        MMI.docstring(::Type{<:$T}) = MMI.docstring_ext($T; descr=$d)
+        MMI.human_name(::Type{<:$T}) = $d
     end
     eval(ex)
     return
 end
 
 function meta(T; input=Unknown, target=Unknown, output=Unknown,
-              weights::Bool=false, descr::String="")
+              weights::Bool=false, human_name::String="")
     ex = quote
         MMI.input_scitype(::Type{<:$T})    = $input
         MMI.output_scitype(::Type{<:$T})   = $output
         MMI.target_scitype(::Type{<:$T})   = $target
         MMI.supports_weights(::Type{<:$T}) = $weights
-        MMI.docstring(::Type{<:$T}) = MMI.docstring_ext($T; descr=$descr)
+        isempty($human_name) || (MMI.human_name(::Type{<:$T}) = $human_name)
     end
     eval(ex)
     return

--- a/src/models/clustering.jl
+++ b/src/models/clustering.jl
@@ -23,7 +23,7 @@ meta(AffinityPropagation,
     target  = AbstractVector{Multiclass},
     # no transform so no output
     weights = false,
-    descr   = "Perform Affinity Propagation Clustering of data."
+    human_name  = "Affinity Propagation Clustering of data"
     )
 
 # ============================================================================
@@ -48,12 +48,20 @@ function MMI.fitted_params(m::AgglomerativeClustering, f)
         children   = f.children_)
 end
 meta(AgglomerativeClustering,
-    input   = Table(Continuous),
-    # no predict nor transform so no target nor output
-    weights = false,
-    descr   = "Recursively merges the pair of clusters that minimally increases a given linkage distance. Note: there is no `predict` or `transform` method
-    associated with it; instead, inspect the `fitted_params`."
+     input   = Table(Continuous),
+     # no predict nor transform so no target nor output
+     weights = false,
     )
+
+"""
+$(MMI.doc_header(AgglomerativeClustering))
+
+Recursively merges the pair of clusters that minimally increases a
+given linkage distance. Note: there is no `predict` or `transform`.
+Instead, inspect the `fitted_params`.
+
+"""
+AgglomerativeClustering
 
 # ============================================================================
 const Birch_ = skcl(:Birch)
@@ -81,8 +89,17 @@ meta(Birch,
     target  = AbstractVector{Multiclass},
     output  = Table(Continuous),
     weights = false,
-    descr   = "Memory-efficient, online-learning algorithm provided as an alternative to MiniBatchKMeans. Note: noisy samples are given the label -1."
     )
+
+"""
+$(MMI.doc_header(Birch))
+
+Memory-efficient, online-learning algorithm provided as an
+alternative to MiniBatchKMeans. Note: noisy samples are given the
+label -1.
+
+"""
+Birch
 
 # ============================================================================
 const DBSCAN_ = skcl(:DBSCAN)
@@ -106,8 +123,17 @@ end
 meta(DBSCAN,
     input   = Table(Continuous),
     weights = false,
-    descr   = "Density-Based Spatial Clustering of Applications with Noise. Finds core samples of high density and expands clusters from them. Good for data which contains clusters of similar density."
     )
+
+"""
+$(MMI.doc_header(DBSCAN))
+
+Density-Based Spatial Clustering of Applications with Noise. Finds
+core samples of high density and expands clusters from them. Good for
+data which contains clusters of similar density.
+
+"""
+DBSCAN
 
 # ============================================================================
 const FeatureAgglomeration_ = skcl(:FeatureAgglomeration)
@@ -139,8 +165,16 @@ meta(FeatureAgglomeration,
     input   = Table(Continuous),
     output  = Table(Continuous),
     weights = false,
-    descr   = "Similar to AgglomerativeClustering, but recursively merges features instead of samples."
     )
+
+"""
+$(MMI.doc_header(FeatureAgglomeration))
+
+Similar to [`AgglomerativeClustering`](@ref), but recursively merges
+features instead of samples."
+
+"""
+FeatureAgglomeration
 
 # ============================================================================
 const KMeans_ = skcl(:KMeans)
@@ -169,12 +203,18 @@ function MMI.fitted_params(m::KMeans, f)
         inertia         = f.inertia_)
 end
 meta(KMeans,
-    input   = Table(Continuous),
-    target  = AbstractVector{Multiclass},
-    output  = Table(Continuous),
-    weights = false,
-    descr   = "K-Means algorithm: find K centroids corresponding to K clusters in the data."
-    )
+     input   = Table(Continuous),
+     target  = AbstractVector{Multiclass},
+     output  = Table(Continuous),
+     weights = false)
+
+"""
+$(MMI.doc_header(KMeans))
+
+K-Means algorithm: find K centroids corresponding to K clusters in the data.
+
+"""
+KMeans
 
 # ============================================================================
 const MiniBatchKMeans_ = skcl(:MiniBatchKMeans)
@@ -207,7 +247,7 @@ meta(MiniBatchKMeans,
     target  = AbstractVector{Multiclass},
     output  = Table(Continuous),
     weights = false,
-    descr   = "Mini-Batch K-Means clustering."
+    human_name   = "Mini-Batch K-Means clustering."
     )
 
 # ============================================================================
@@ -233,9 +273,21 @@ end
 meta(MeanShift,
     input   = Table(Continuous),
     target  = AbstractVector{Multiclass},
-    weights = false,
-    descr   = "Mean shift clustering using a flat kernel. Mean shift clustering aims to discover \"blobs\" in a smooth density of samples. It is a centroid-based algorithm, which works by updating candidates for centroids to be the mean of the points within a given region. These candidates are then filtered in a post-processing stage to eliminate near-duplicates to form the final set of centroids."
+    weights = false
     )
+
+"""
+$(MMI.doc_header(MeanShift))
+
+Mean shift clustering using a flat kernel. Mean shift clustering aims
+to discover \"blobs\" in a smooth density of samples. It is a
+centroid-based algorithm, which works by updating candidates for
+centroids to be the mean of the points within a given region. These
+candidates are then filtered in a post-processing stage to eliminate
+near-duplicates to form the final set of centroids."
+
+"""
+MeanShift
 
 # ============================================================================
 const OPTICS_ = skcl(:OPTICS)
@@ -267,8 +319,19 @@ end
 meta(OPTICS,
     input   = Table(Continuous),
     weights = false,
-    descr   = "OPTICS (Ordering Points To Identify the Clustering Structure), closely related to DBSCAN, finds core sample of high density and expands clusters from them. Unlike DBSCAN, keeps cluster hierarchy for a variable neighborhood radius. Better suited for usage on large datasets than the current sklearn implementation of DBSCAN."
     )
+
+"""
+$(MMI.doc_header(OPTICS))
+
+OPTICS (Ordering Points To Identify the Clustering Structure), closely
+related to [`DBSCAN'](@ref), finds core sample of high density and expands
+clusters from them. Unlike DBSCAN, keeps cluster hierarchy for a
+variable neighborhood radius. Better suited for usage on large
+datasets than the current sklearn implementation of DBSCAN.
+
+"""
+OPTICS
 
 # ============================================================================
 const SpectralClustering_ = skcl(:SpectralClustering)
@@ -294,10 +357,21 @@ function MMI.fitted_params(m::SpectralClustering, f)
 end
 meta(SpectralClustering,
     input   = Table(Continuous),
-    weights = false,
-    descr   = "Apply clustering to a projection of the normalized Laplacian.
-    In practice Spectral Clustering is very useful when the structure of the individual clusters is highly non-convex or more generally when a measure of the center and spread of the cluster is not a suitable description of the complete cluster. For instance when clusters are nested circles on the 2D plane."
+    weights = false
     )
+
+"""
+$(MMI.doc_header(SpectralClustering))
+
+Apply clustering to a projection of the normalized Laplacian.  In
+practice spectral clustering is very useful when the structure of the
+individual clusters is highly non-convex or more generally when a
+measure of the center and spread of the cluster is not a suitable
+description of the complete cluster. For instance when clusters are
+nested circles on the 2D plane.
+
+"""
+SpectralClustering
 
 # NOTE: the two models below are weird, not bothering with them for now
 # # ============================================================================

--- a/src/models/clustering.jl
+++ b/src/models/clustering.jl
@@ -189,7 +189,6 @@ const KMeans_ = skcl(:KMeans)
     n_jobs::Option{Int} = nothing
     algorithm::String   = "auto"::(_ in ("auto", "full", "elkane"))
     # long
-    precompute_distances::Union{Bool,String} = "auto"::(_ isa Bool || _ == "auto")
     init::Union{AbstractArray,String}        = "k-means++"::(_ isa AbstractArray || _ in ("k-means++", "random"))
 end
 @sku_transform KMeans

--- a/src/models/clustering.jl
+++ b/src/models/clustering.jl
@@ -186,7 +186,6 @@ const KMeans_ = skcl(:KMeans)
     verbose::Int        = 0::(_ ≥ 0)
     random_state::Any   = nothing
     copy_x::Bool        = true
-    n_jobs::Option{Int} = nothing
     algorithm::String   = "auto"::(_ in ("auto", "full", "elkane"))
     # long
     init::Union{AbstractArray,String}        = "k-means++"::(_ isa AbstractArray || _ in ("k-means++", "random"))

--- a/src/models/discriminant-analysis.jl
+++ b/src/models/discriminant-analysis.jl
@@ -22,7 +22,7 @@ meta(BayesianLDA,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Bayesian Linear Discriminant Analysis."
+    human_name   = "Bayesian linear discriminant analysis"
     )
 
 # ============================================================================
@@ -44,5 +44,5 @@ meta(BayesianQDA,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Bayesian Quadratic Discriminant Analysis."
+    human_name   = "Bayesian quadratic discriminant analysis"
     )

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -12,7 +12,7 @@ MMI.fitted_params(model::AdaBoostRegressor, (f, _, _)) = (
     estimator_errors     = f.estimator_errors_,
     feature_importances  = f.feature_importances_
     )
-descr(AdaBoostRegressor, "AdaBoost ensemble regression.")
+add_human_name_trait(AdaBoostRegressor, "AdaBoost ensemble regression")
 
 # ----------------------------------------------------------------------------
 const AdaBoostClassifier_ = sken(:AdaBoostClassifier)
@@ -34,7 +34,6 @@ meta(AdaBoostClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Adaboost ensemble classifier."
     )
 
 # ============================================================================
@@ -59,7 +58,7 @@ MMI.fitted_params(model::BaggingRegressor, (f, _, _)) = (
     oob_score           = model.oob_score ? f.oob_score_ : nothing,
     oob_prediction      = model.oob_score ? f.oob_prediction_ : nothing
     )
-descr(BaggingRegressor, "Bagging ensemble regression.")
+add_human_name_trait(BaggingRegressor, "bagging ensemble regressor")
 
 # ----------------------------------------------------------------------------
 const BaggingClassifier_ = sken(:BaggingClassifier)
@@ -90,7 +89,7 @@ meta(BaggingClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Bagging ensemble classifier."
+    human_name   = "bagging ensemble classifier"
     )
 
 # ============================================================================
@@ -126,7 +125,7 @@ MMI.fitted_params(m::GradientBoostingRegressor, (f, _, _)) = (
     estimators          = f.estimators_,
     oob_improvement     = m.subsample < 1 ? f.oob_improvement_ : nothing
     )
-descr(GradientBoostingRegressor, "Gradient boosting ensemble regression.")
+add_human_name_trait(GradientBoostingRegressor, "gradient boosting ensemble regression")
 
 # ----------------------------------------------------------------------------
 const GradientBoostingClassifier_ = sken(:GradientBoostingClassifier)
@@ -164,8 +163,7 @@ MMI.fitted_params(m::GradientBoostingClassifier, (f, _, _)) = (
 meta(GradientBoostingClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
-    weights = false,
-    descr   = "Gradient boosting ensemble classifier."
+    weights = false
     )
 
 # ============================================================================
@@ -201,8 +199,7 @@ MMI.fitted_params(model::RandomForestRegressor, (f, _, _)) = (
 meta(RandomForestRegressor,
     input   = Table(Count,Continuous),
     target  = AbstractVector{Continuous},
-    weights = false,
-    descr   = "Random forest regressor."
+    weights = false
     )
 
 # ----------------------------------------------------------------------------
@@ -241,8 +238,7 @@ MMI.fitted_params(m::RandomForestClassifier, (f, _, _)) = (
 meta(RandomForestClassifier,
     input   = Table(Count,Continuous),
     target  = AbstractVector{<:Finite},
-    weights = false,
-    descr   = "Random forest classifier."
+    weights = false
     )
 
 const ENSEMBLE_REG = Union{Type{<:AdaBoostRegressor}, Type{<:BaggingRegressor}, Type{<:GradientBoostingRegressor}}
@@ -280,9 +276,18 @@ MMI.fitted_params(m::ExtraTreesRegressor, (f, _, _)) = (
 meta(ExtraTreesRegressor,
     input   = Table(Continuous),
     target  = AbstractVector{Continuous},
-    weights = false,
-    descr   = "Extra trees regressor, fits a number of randomized decision trees on various sub-samples of the dataset and uses averaging to improve the predictive accuracy and control over-fitting."
+    weights = false
     )
+
+"""
+$(MMI.doc_header(ExtraTreesRegressor))
+
+Extra trees regressor, fits a number of randomized decision trees on
+various sub-samples of the dataset and uses averaging to improve the
+predictive accuracy and control over-fitting.
+
+"""
+ExtraTreesRegressor
 
 # ----------------------------------------------------------------------------
 const ExtraTreesClassifier_ = sken(:ExtraTreesClassifier)
@@ -317,6 +322,15 @@ MMI.fitted_params(m::ExtraTreesClassifier, (f, _, _)) = (
 meta(ExtraTreesClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
-    weights = false,
-    descr   = "Extra trees classifier, fits a number of randomized decision trees on various sub-samples of the dataset and uses averaging to improve the predictive accuracy and control over-fitting."
+    weights = false
     )
+
+"""
+$(MMI.doc_header(ExtraTreesClassifier))
+
+Extra trees classifier, fits a number of randomized decision trees on
+various sub-samples of the dataset and uses averaging to improve the
+predictive accuracy and control over-fitting.
+
+"""
+ExtraTreesClassifier

--- a/src/models/gaussian-process.jl
+++ b/src/models/gaussian-process.jl
@@ -21,7 +21,7 @@ meta(GaussianProcessRegressor,
     input   = Table(Continuous),
     target  = AbstractVector{Continuous},
     weights = false,
-    descr   = "Gaussian process regressor."
+    human_name   = "Gaussian process regressor"
     )
 
 # ============================================================================
@@ -46,5 +46,5 @@ meta(GaussianProcessClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Gaussian process classifier."
+    human_name   = "Gaussian process classifier"
     )

--- a/src/models/linear-classifiers.jl
+++ b/src/models/linear-classifiers.jl
@@ -25,7 +25,7 @@ meta(LogisticClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Logistic regression classifier."
+    human_name  = "logistic regression classifier"
     )
 
 # ============================================================================
@@ -64,7 +64,7 @@ meta(LogisticCVClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Logistic regression classifier $CV."
+    human_name   = "logistic regression classifier $CV"
     )
 
 # ============================================================================
@@ -94,7 +94,7 @@ meta(PassiveAggressiveClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Passive aggressive classifier."
+    human_name   = "passive aggressive classifier"
     )
 
 # ============================================================================
@@ -124,7 +124,6 @@ meta(PerceptronClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Perceptron classifier."
     )
 
 # ============================================================================
@@ -148,7 +147,7 @@ meta(RidgeClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Ridge regression classifier."
+    human_name   = "ridge regression classifier"
     )
 
 # ============================================================================
@@ -170,7 +169,7 @@ meta(RidgeCVClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Ridge regression classifier $CV."
+    human_name   = "ridge regression classifier $CV"
     )
 
 # ============================================================================
@@ -234,6 +233,5 @@ MMI.fitted_params(m::ProbabilisticSGDClassifier, (f,_,_)) = (
 meta.((SGDClassifier, ProbabilisticSGDClassifier),
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
-    weights = false,
-    descr   = "Linear classifier with stochastic gradient descent training."
+    weights = false
     )

--- a/src/models/linear-regressors-multi.jl
+++ b/src/models/linear-regressors-multi.jl
@@ -13,7 +13,7 @@ MMI.fitted_params(model::MultiTaskLassoRegressor, (fitresult, _, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
-descr(MultiTaskLassoRegressor, "MultiTask Lasso regression.")
+add_human_name_trait(MultiTaskLassoRegressor, "multi-target lasso regressor")
 
 # ==============================================================================
 const MultiTaskLassoCVRegressor_ = sklm(:MultiTaskLassoCV)
@@ -39,7 +39,7 @@ MMI.fitted_params(model::MultiTaskLassoCVRegressor, (fitresult, _, _)) = (
     mse_path  = fitresult.mse_path_,
     alphas    = fitresult.alphas_
     )
-descr(MultiTaskLassoCVRegressor, "MultiTask Lasso regression $CV.")
+add_human_name_trait(MultiTaskLassoCVRegressor, "multi-target lasso regressor $CV")
 
 # ==============================================================================
 const MultiTaskElasticNetRegressor_ = sklm(:MultiTaskElasticNet)
@@ -59,7 +59,7 @@ MMI.fitted_params(model::MultiTaskElasticNetRegressor, (fitresult, _, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
-descr(MultiTaskElasticNetRegressor, "MultiTask Elastic Net regression.")
+add_human_name_trait(MultiTaskElasticNetRegressor, "multi-target elastic net regressor")
 
 # ==============================================================================
 const MultiTaskElasticNetCVRegressor_ = sklm(:MultiTaskElasticNetCV)
@@ -86,7 +86,8 @@ MMI.fitted_params(model::MultiTaskElasticNetCVRegressor, (fitresult, _, _)) = (
     mse_path  = fitresult.mse_path_,
     l1_ratio  = fitresult.l1_ratio_
     )
-descr(MultiTaskElasticNetCVRegressor, "MultiTask Elastic Net regression $CV.")
+add_human_name_trait(MultiTaskElasticNetCVRegressor, "multi-target elastic "*
+                     "net regressor $CV")
 
 
 const SKL_REGS_MULTI = Union{

--- a/src/models/linear-regressors.jl
+++ b/src/models/linear-regressors.jl
@@ -21,7 +21,7 @@ MMI.fitted_params(model::ARDRegressor, (fitresult, _, _)) = (
     sigma     = fitresult.sigma_,
     scores    = fitresult.scores_
     )
-descr(ARDRegressor, "Bayesian ARD regression.")
+add_human_name_trait(ARDRegressor, "Bayesian ARD regressor")
 
 # =============================================================================
 const BayesianRidgeRegressor_ = sklm(:BayesianRidge)
@@ -46,7 +46,7 @@ MMI.fitted_params(model::BayesianRidgeRegressor, (fitresult, _, _)) = (
     sigma     = fitresult.sigma_,
     scores    = fitresult.scores_
     )
-descr(BayesianRidgeRegressor, "Bayesian ridge regression.")
+add_human_name_trait(BayesianRidgeRegressor, "Bayesian ridge regressor")
 
 # =============================================================================
 const ElasticNetRegressor_ = sklm(:ElasticNet)
@@ -68,7 +68,6 @@ MMI.fitted_params(model::ElasticNetRegressor, (fitresult, _, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     )
-descr(ElasticNetRegressor, "Elastic net regression.")
 
 # =============================================================================
 const ElasticNetCVRegressor_ = sklm(:ElasticNetCV)
@@ -97,7 +96,7 @@ MMI.fitted_params(model::ElasticNetCVRegressor, (fitresult, _, _)) = (
     mse_path  = fitresult.mse_path_,
     alphas    = fitresult.alphas_
     )
-descr(ElasticNetCVRegressor, "Elastic net regression $CV.")
+add_human_name_trait(ElasticNetCVRegressor, "elastic net regression $CV")
 
 # =============================================================================
 const HuberRegressor_ = sklm(:HuberRegressor)
@@ -115,7 +114,7 @@ MMI.fitted_params(model::HuberRegressor, (fitresult, _, _)) = (
     scale     = fitresult.scale_,
     outliers  = fitresult.outliers_
     )
-descr(HuberRegressor, "Huber regression.")
+add_human_name_trait(HuberRegressor, "Huber regressor")
 
 # =============================================================================
 const LarsRegressor_ = sklm(:Lars)
@@ -136,7 +135,7 @@ MMI.fitted_params(model::LarsRegressor, (fitresult, _, _)) = (
     active    = fitresult.active_,
     coef_path = fitresult.coef_path_
     )
-descr(LarsRegressor, "Lars regression.")
+add_human_name_trait(LarsRegressor, "least angle regressor (LARS)")
 
 # =============================================================================
 const LarsCVRegressor_ = sklm(:LarsCV)
@@ -161,7 +160,7 @@ MMI.fitted_params(model::LarsCVRegressor, (fitresult, _, _)) = (
     mse_path  = fitresult.mse_path_,
     coef_path = fitresult.coef_path_
     )
-descr(LarsCVRegressor, "Lars regression $CV.")
+add_human_name_trait(LarsCVRegressor, "least angle regressor $CV")
 
 # =============================================================================
 const LassoRegressor_ = sklm(:Lasso)
@@ -182,7 +181,6 @@ MMI.fitted_params(model::LassoRegressor, (fitresult, _, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     )
-descr(LassoRegressor, "Lasso regression.")
 
 # =============================================================================
 const LassoCVRegressor_ = sklm(:LassoCV)
@@ -211,7 +209,7 @@ MMI.fitted_params(model::LassoCVRegressor, (fitresult, _, _)) = (
     mse_path  = fitresult.mse_path_,
     dual_gap  = fitresult.dual_gap_
     )
-descr(LassoCVRegressor, "Lasso regression $CV.")
+add_human_name_trait(LassoCVRegressor, "lasso regressor $CV")
 
 # =============================================================================
 const LassoLarsRegressor_ = sklm(:LassoLars)
@@ -234,7 +232,7 @@ MMI.fitted_params(model::LassoLarsRegressor, (fitresult, _, _)) = (
     active    = fitresult.active_,
     coef_path = fitresult.coef_path_
     )
-descr(LassoLarsRegressor, "Lasso model fit with least angle regression (LARS).")
+add_human_name_trait(LassoLarsRegressor, "Lasso model fit with least angle regression (LARS)")
 
 # =============================================================================
 const LassoLarsCVRegressor_ = sklm(:LassoLarsCV)
@@ -260,7 +258,8 @@ MMI.fitted_params(model::LassoLarsCVRegressor, (fitresult, _, _)) = (
     cv_alphas = fitresult.cv_alphas_,
     mse_path  = fitresult.mse_path_
     )
-descr(LassoLarsCVRegressor, "Lasso model fit with least angle regression (LARS) $CV.")
+add_human_name_trait(LassoLarsCVRegressor, "Lasso model fit with least angle "*
+                     "regression (LARS) $CV")
 
 # =============================================================================
 const LassoLarsICRegressor_ = sklm(:LassoLarsIC)
@@ -280,7 +279,8 @@ MMI.fitted_params(model::LassoLarsICRegressor, (fitresult, _, _)) = (
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_
     )
-descr(LassoLarsICRegressor, "Lasso model with Lars using BIC or AIC for model selection.")
+add_human_name_trait(LassoLarsICRegressor, "Lasso model with LARS using "*
+                     "BIC or AIC for model selection")
 
 # =============================================================================
 const LinearRegressor_ = sklm(:LinearRegression)
@@ -294,7 +294,7 @@ MMI.fitted_params(model::LinearRegressor, (fitresult, _, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
-descr(LinearRegressor, "Ordinary least-square regression (OLS).")
+add_human_name_trait(LinearRegressor, "ordinary least-squares regressor (OLS)")
 
 # =============================================================================
 const OrthogonalMatchingPursuitRegressor_ = sklm(:OrthogonalMatchingPursuit)
@@ -309,7 +309,6 @@ MMI.fitted_params(model::OrthogonalMatchingPursuitRegressor, (fitresult, _, _)) 
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
-descr(OrthogonalMatchingPursuitRegressor, "Orthogonal Matching Pursuit (OMP) model.")
 
 # =============================================================================
 const OrthogonalMatchingPursuitCVRegressor_ = sklm(:OrthogonalMatchingPursuitCV)
@@ -327,7 +326,8 @@ MMI.fitted_params(model::OrthogonalMatchingPursuitCVRegressor, (fitresult, _, _)
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     n_nonzero_coefs = fitresult.n_nonzero_coefs_
     )
-descr(OrthogonalMatchingPursuitCVRegressor, "Orthogonal Matching Pursuit (OMP) model $CV.")
+add_human_name_trait(OrthogonalMatchingPursuitCVRegressor, "orthogonal ,atching pursuit "*
+                     "(OMP) model $CV")
 
 # =============================================================================
 const PassiveAggressiveRegressor_ = sklm(:PassiveAggressiveRegressor)
@@ -351,7 +351,6 @@ MMI.fitted_params(model::PassiveAggressiveRegressor, (fitresult, _, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
-descr(PassiveAggressiveRegressor, "Passive Aggressive Regressor.")
 
 # =============================================================================
 const RANSACRegressor_ = sklm(:RANSACRegressor)
@@ -377,7 +376,6 @@ MMI.fitted_params(m::RANSACRegressor, (f, _, _)) = (
     n_skips_invalid_data  = f.n_skips_invalid_data_,
     n_skips_invalid_model = f.n_skips_invalid_model_
     )
-descr(RANSACRegressor, "RANSAC regressor.")
 
 # =============================================================================
 const RidgeRegressor_ = sklm(:Ridge)
@@ -395,7 +393,6 @@ MMI.fitted_params(model::RidgeRegressor, (fitresult, _, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
-descr(RidgeRegressor, "Ridge regression.")
 
 # =============================================================================
 const RidgeCVRegressor_ = sklm(:RidgeCV)
@@ -414,7 +411,7 @@ MMI.fitted_params(model::RidgeCVRegressor, (fitresult, _, _)) = (
     alpha     = fitresult.alpha_,
     cv_values = model.store_cv_values ? fitresult.cv_values_ : nothing
     )
-descr(RidgeCVRegressor, "Ridge regression $CV.")
+add_human_name_trait(RidgeCVRegressor, "ridge regressor $CV")
 
 # =============================================================================
 const SGDRegressor_ = sklm(:SGDRegressor)
@@ -445,7 +442,7 @@ MMI.fitted_params(model::SGDRegressor, (fitresult, _, _)) = (
     average_coef      = model.average ? fitresult.average_coef_ : nothing,
     average_intercept = model.average ? ifelse(model.fit_intercept, fitresult.average_intercept_, nothing) : nothing
     )
-descr(SGDRegressor, "Stochastic gradient descent-based regressor.")
+add_human_name_trait(SGDRegressor, "stochastic gradient descent-based regressor")
 
 # =============================================================================
 const TheilSenRegressor_ = sklm(:TheilSenRegressor)
@@ -466,7 +463,7 @@ MMI.fitted_params(model::TheilSenRegressor, (fitresult, _, _)) = (
     breakdown       = fitresult.breakdown_,
     n_subpopulation = fitresult.n_subpopulation_
     )
-descr(TheilSenRegressor, "Theil-Sen regressor.")
+add_human_name_trait(TheilSenRegressor, "Theil-Sen regressor")
 
 
 # Metadata for Continuous -> Vector{Continuous}

--- a/src/models/misc.jl
+++ b/src/models/misc.jl
@@ -11,9 +11,16 @@ MMI.fitted_params(m::DummyRegressor, (f, _, _)) = (
 meta(DummyRegressor,
     input   = Table(Continuous),
     target  = AbstractVector{Continuous},
-    weights = false,
-    descr   = "DummyRegressor is a regressor that makes predictions using simple rules."
+    weights = false
     )
+
+"""
+$(MMI.doc_header(DummyRegressor))
+
+DummyRegressor is a regressor that makes predictions using simple rules.
+
+"""
+DummyRegressor
 
 # ----------------------------------------------------------------------------
 const DummyClassifier_ = skdu(:DummyClassifier)
@@ -31,8 +38,15 @@ meta(DummyClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "DummyClassifier is a classifier that makes predictions using simple rules."
-    )
+     )
+
+"""
+$(MMI.doc_header(DummyClassifier))
+
+DummyClassifier is a classifier that makes predictions using simple rules.
+
+"""
+DummyClassifier
 
 # ============================================================================
 const GaussianNBClassifier_ = sknb(:GaussianNB)
@@ -51,7 +65,7 @@ meta(GaussianNBClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "Gaussian naive bayes model."
+    human_name   = "Gaussian naive Bayes classifier"
     )
 
 # ============================================================================
@@ -71,9 +85,20 @@ MMI.fitted_params(m::BernoulliNBClassifier, (f, _, _)) = (
 meta(BernoulliNBClassifier,
     input   = Table(Count),      # it expects binary but binarize takes care of that
     target  = AbstractVector{<:Finite},
-    weights = false,
-    descr   = "Binomial naive bayes classifier. It is suitable for classification with binary features; features will be binarized based on the `binarize` keyword (unless it's `nothing` in which case the features are assumed to be binary)."
-    )
+     weights = false,
+     human_name = "Bernoulli naive Bayes classifier"
+     )
+
+"""
+$(MMI.doc_header(BernoulliNBClassifier))
+
+Binomial naive bayes classifier. It is suitable for classification
+with binary features; features will be binarized based on the
+`binarize` keyword (unless it's `nothing` in which case the features
+are assumed to be binary).
+
+"""
+BernoulliNBClassifier
 
 # ============================================================================
 const MultinomialNBClassifier_ = sknb(:MultinomialNB)
@@ -93,9 +118,18 @@ MMI.fitted_params(m::MultinomialNBClassifier, (f, _, _)) = (
 meta(MultinomialNBClassifier,
     input   = Table(Count),        # NOTE: sklearn may also accept continuous (tf-idf)
     target  = AbstractVector{<:Finite},
-    weights = false,
-    descr   = "Multinomial naive bayes classifier. It is suitable for classification with discrete features (e.g. word counts for text classification)."
-    )
+     weights = false,
+     human_name = "multinomial naive Bayes classifier"
+     )
+
+"""
+$(MMI.doc_header(MultinomialNBClassifier))
+
+Multinomial naive bayes classifier. It is suitable for classification
+with discrete features (e.g. word counts for text classification).
+
+"""
+MultinomialNBClassifier
 
 # ============================================================================
 const ComplementNBClassifier_ = sknb(:ComplementNB)
@@ -115,9 +149,18 @@ MMI.fitted_params(m::ComplementNBClassifier, (f, _, _)) = (
 meta(ComplementNBClassifier,
     input   = Table(Count),        # NOTE: sklearn may also accept continuous (tf-idf)
     target  = AbstractVector{<:Finite},
-    weights = false,
-    descr   = "Similar to Multinomial NB classifier but with more robust assumptions. Suited for imbalanced datasets."
-    )
+     weights = false,
+     human_name = "Complement naive Bayes classifier"
+     )
+
+"""
+$(MMI.doc_header(ComplementNBClassifier))
+
+Similar to [`MultinomialNBClassifier`](@ref) but with more robust
+assumptions. Suited for imbalanced datasets.
+
+"""
+ComplementNBClassifier
 
 # ============================================================================
 const KNeighborsRegressor_ = skne(:KNeighborsRegressor)
@@ -139,8 +182,8 @@ meta(KNeighborsRegressor,
     input=Table(Continuous),
     target=AbstractVector{Continuous},
     weights=false,
-    descr="K-Nearest Neighbors regressor: predicts the response associated with a new point by taking an average of the response of the K-nearest points."
-    )
+     human_name = "K-nearest neighbors regressor"
+     )
 
 # ----------------------------------------------------------------------------
 const KNeighborsClassifier_ = skne(:KNeighborsClassifier)
@@ -164,5 +207,5 @@ meta(KNeighborsClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
     weights = false,
-    descr   = "K-Nearest Neighbors classifier: predicts the class associated with a new point by taking a vote over the classes of the K-nearest points."
+    human_name   = "K-nearest neighbors classifier"
     )

--- a/src/models/svm.jl
+++ b/src/models/svm.jl
@@ -19,7 +19,7 @@ MMI.fitted_params(m::SVMLinearClassifier, (f, _, _)) = (
 meta(SVMLinearClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
-    descr   = "Linear Support Vector Classification."
+    human_name   = "linear support vector classifier"
     )
 
 # ----------------------------------------------------------------------------
@@ -52,7 +52,7 @@ MMI.fitted_params(m::SVMClassifier, (f, _, _)) = (
 meta(SVMClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
-    descr   = "C-Support Vector Classification."
+    human_name   = "C-support vector classifier"
     )
 
 # ============================================================================
@@ -75,7 +75,7 @@ MMI.fitted_params(m::SVMLinearRegressor, (f, _, _)) = (
 meta(SVMLinearRegressor,
     input   = Table(Continuous),
     target  = AbstractVector{Continuous},
-    descr   = "Linear Support Vector Regression."
+    human_name   = "linear support vector regressor"
     )
 
 # ----------------------------------------------------------------------------
@@ -103,7 +103,7 @@ MMI.fitted_params(m::SVMRegressor, (f, _, _)) = (
 meta(SVMRegressor,
     input   = Table(Continuous),
     target  = AbstractVector{Continuous},
-    descr   = "Epsilon-Support Vector Regression."
+    human_name   = "epsilon-support vector regressor"
     )
 
 # ============================================================================
@@ -138,7 +138,7 @@ MMI.fitted_params(m::SVMNuClassifier, (f, _, _)) = (
 meta(SVMNuClassifier,
     input   = Table(Continuous),
     target  = AbstractVector{<:Finite},
-    descr   = "Nu-Support Vector Classification."
+    human_name   = "nu-support vector classifier"
     )
 
 # ============================================================================
@@ -165,5 +165,5 @@ MMI.fitted_params(m::SVMNuRegressor, (f, _, _)) = (
 meta(SVMNuRegressor,
     input   = Table(Continuous),
     target  = AbstractVector{Continuous},
-    descr   = "Nu-Support Vector Regression."
+    human_name   = "nu-support vector regressor"
     )


### PR DESCRIPTION
As detailed in this #38:

- Cleanup document strings
- Resolve minor issue with MLJModelInterface 0.1.4 release 
- (**breaking**) Remove fields `precompute_distances` and `n_jobs` from `KMeans` as unsupported in the scikit-learn 1.0 model
- Require Julia 1.6 or higher