### PR TITLE
Add generic interface tests from MLJTestInterface.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,9 @@ julia = "1.6"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+MLJTestInterface = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StableRNGs", "Test", "MLJBase"]
+test = ["StableRNGs", "MLJTestInterface", "Test", "MLJBase"]

--- a/test/generic_api_tests.jl
+++ b/test/generic_api_tests.jl
@@ -1,0 +1,97 @@
+using MLJTestInterface
+import MLJBase
+import MLJBase: finaltypes,
+    Continuous,
+    Finite,
+    Multiclass,
+    target_scitype,
+    input_scitype,
+    is_supervised,
+    package_name,
+    Model,
+    Table
+
+const MODELS = filter(finaltypes(Model)) do m
+    package_name(m) == "ScikitLearn"
+end
+
+const SINGLE_TARGET_REGRESSORS = filter(MODELS) do m
+     AbstractVector{Continuous} <: target_scitype(m) &&
+        is_supervised(m)
+end
+
+const SINGLE_TARGET_CLASSIFIERS = filter(MODELS) do m
+    AbstractVector{Multiclass{3}} <: target_scitype(m) &&
+        AbstractVector{Multiclass{2}} <: target_scitype(m) &&
+        Table(Continuous) <: input_scitype(m) &&
+        is_supervised(m)
+end
+
+const TRANSFORMERS = filter(MODELS) do m
+     Table(Continuous) <: input_scitype(m) &&
+         !is_supervised(m) &&
+         # excluded because it does not converge:
+         m != AffinityPropagation
+end
+
+bad_single_target_classifiers = [
+    # https://github.com/JuliaAI/MLJScikitLearnInterface.jl/issues/48
+    PassiveAggressiveClassifier,
+    PerceptronClassifier,
+    SGDClassifier,
+    SVMClassifier,
+    SVMNuClassifier,
+    BayesianQDA,
+    ProbabilisticSGDClassifier,
+    SVMLinearClassifier,
+    SVMLinearClassifier,
+    LogisticCVClassifier,
+    LogisticClassifier,
+    GaussianProcessClassifier,
+    GradientBoostingClassifier,
+]
+
+@test_broken isempty(bad_single_target_classifiers)
+
+@testset "generic interface tests" begin
+    @testset "regressors"  begin
+        failures, summary = MLJTestInterface.test(
+            SINGLE_TARGET_REGRESSORS,
+            MLJTestInterface.make_regression()...;
+            mod=@__MODULE__,
+            verbosity=0, # bump to debug
+            throw=false, # set to true to debug
+        )
+        @test isempty(failures)
+    end
+    @testset "classifiers" begin
+        for data in [
+            MLJTestInterface.make_binary(),
+            MLJTestInterface.make_multiclass(),
+        ]
+            failures, summary = MLJTestInterface.test(
+                setdiff(
+                    SINGLE_TARGET_CLASSIFIERS,
+                    bad_single_target_classifiers,
+                ),
+                data...;
+                mod=@__MODULE__,
+                verbosity=0, # bump to debug
+                throw=false, # set to true to debug
+            )
+            @test isempty(failures)
+        end
+    end
+    @testset "transformers" begin
+        failures, summary = MLJTestInterface.test(
+            TRANSFORMERS,
+            MLJTestInterface.make_regression()[1];
+            mod=@__MODULE__,
+            verbosity=0, # bump to debug
+            throw=false, # set to true to debug
+        )
+        @test isempty(failures)
+    end
+end
+
+true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,3 +18,5 @@ println("\ndiscriminant-analysis");   include("models/discriminant-analysis.jl")
 println("\ngaussian-process");        include("models/gaussian-process.jl")
 println("\nensemble");                include("models/ensemble.jl")
 println("\nclustering");              include("models/clustering.jl")
+
+prinln("\ngeneric interface tests");  include("generic_api_tests.jl")


### PR DESCRIPTION
This passes tests locally but using an old version of sk-learn, 0.22.1.

This PR should be rebased after #50 is merged.