### PR TITLE
update code to support sklearn v1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 env:
   PYTHON: Conda
-  # The following is needed for Julia <=0.8.4 on Linux OS
-  LPATH: /home/runner/.julia/conda/3/x86_64/lib
-
   
 on:
   pull_request:
@@ -47,11 +44,14 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
-# The following is needed for Julia <=0.8.4 on Linux OS
+# The following is needed for Julia <=0.8.4 on Linux OS 
+# due to old version of libstcxx used by Julia
       - name: "Export LD_LIBRARY_PATH envrioment variable"
         if: ${{matrix.version == '1.6'}}
-        run: export LD_LIBRARY_PATH=$LPATH
+        run: echo "LD_LIBRARY_PATH=/home/runner/.julia/conda/3/x86_64/lib" >> $GITHUB_ENV
       - uses: julia-actions/julia-runtest@v1
+        env:
+          LD_LIBRARY_PATH: /home/runner/.julia/conda/3/x86_64/lib
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
 # The following is needed for Julia <=0.8.4 on Linux OS
       - name: "Export LD_LIBRARY_PATH envrioment variable"
-        if: ${{matrix.julia-version == '1.6'}}
+        if: ${{matrix.version == '1.6'}}
         run: export LD_LIBRARY_PATH=$LPATH
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 env:
   PYTHON: Conda
-  # uncomment the line below when #42 comes up again
-  # LD_LIBRARY_PATH: /home/runner/.julia/conda/3/x86_64/lib
+  # The following is needed for Julia <=0.8.4 on Linux OS
+  LD_LIBRARY_PATH: /home/runner/.julia/conda/3/x86_64/lib
   
 on:
   pull_request:
@@ -46,11 +46,10 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
-# uncomment the next four lines (and one other marked above) when #42 comes up again.
-      #- name: "Install Conda"
-      #  run: julia -e 'using Pkg; Pkg.add("Conda");'
-      #- name: "Install Scikit-learn"
-      #  run: cd $LD_LIBRARY_PATH
+# The following is needed for Julia <=0.8.4 on Linux OS
+      - name: "Export LD_LIBRARY_PATH envrioment variable"
+        if: ${{matrix.julia-version == '1.6'}}
+        run: export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 env:
   PYTHON: Conda
-# remove next line (and others marked below) when #42 properly resolved
-  LD_LIBRARY_PATH: /home/runner/.julia/conda/3/lib
+  # uncomment the line below when #42 comes up again
+  # LD_LIBRARY_PATH: /home/runner/.julia/conda/3/x86_64/lib
   
 on:
   pull_request:
@@ -46,11 +46,11 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
-# remove next four lines (and one other marked above) when #42 properly resolved
-      - name: "Install Conda"
-        run: julia -e 'using Pkg; Pkg.add("Conda");'
-      - name: "Install Scikit-learn"
-        run: cd $LD_LIBRARY_PATH
+# uncomment the next four lines (and one other marked above) when #42 comes up again.
+      #- name: "Install Conda"
+      #  run: julia -e 'using Pkg; Pkg.add("Conda");'
+      #- name: "Install Scikit-learn"
+      #  run: cd $LD_LIBRARY_PATH
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 env:
   PYTHON: Conda
   # The following is needed for Julia <=0.8.4 on Linux OS
-  LD_LIBRARY_PATH: /home/runner/.julia/conda/3/x86_64/lib
+  LPATH: /home/runner/.julia/conda/3/x86_64/lib
 
   
 on:
@@ -50,7 +50,7 @@ jobs:
 # The following is needed for Julia <=0.8.4 on Linux OS
       - name: "Export LD_LIBRARY_PATH envrioment variable"
         if: ${{matrix.julia-version == '1.6'}}
-        run: export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+        run: export LD_LIBRARY_PATH=$LPATH
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ ScikitLearn = "3646fa90-6ef7-5e7e-9f22-8aca16db6324"
 [compat]
 MLJModelInterface = "1.4"
 PyCall = "1"
-ScikitLearn = "0.5,0.6"
+ScikitLearn = "0.7"
 julia = "1.6"
 
 [extras]

--- a/src/models/clustering.jl
+++ b/src/models/clustering.jl
@@ -186,7 +186,8 @@ const KMeans_ = skcl(:KMeans)
     verbose::Int        = 0::(_ ≥ 0)
     random_state::Any   = nothing
     copy_x::Bool        = true
-    algorithm::String   = "auto"::(_ in ("auto", "full", "elkane"))
+    ## TODO: Remove the "auto" and "full" options when python sklearn releases v1.3
+    algorithm::String   = "lloyd"::(_ in ("auto", "full", "elkane", "lloyd"))
     # long
     init::Union{AbstractArray,String}        = "k-means++"::(_ isa AbstractArray || _ in ("k-means++", "random"))
 end

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -1,6 +1,6 @@
 const AdaBoostRegressor_ = sken(:AdaBoostRegressor)
 @sk_reg mutable struct AdaBoostRegressor <: MMI.Deterministic
-    base_estimator::Any    = nothing
+    estimator::Any    = nothing
     n_estimators::Int      = 50::(_ > 0)
     learning_rate::Float64 = 1.0::(_ > 0)
     loss::String           = "linear"::(_ in ("linear","square","exponential"))
@@ -17,7 +17,7 @@ add_human_name_trait(AdaBoostRegressor, "AdaBoost ensemble regression")
 # ----------------------------------------------------------------------------
 const AdaBoostClassifier_ = sken(:AdaBoostClassifier)
 @sk_clf mutable struct AdaBoostClassifier <: MMI.Probabilistic
-    base_estimator::Any    = nothing
+    estimator::Any    = nothing
     n_estimators::Int      = 50::(_ > 0)
     learning_rate::Float64 = 1.0::(_ > 0)
     algorithm::String      = "SAMME.R"::(_ in ("SAMME", "SAMME.R"))
@@ -39,7 +39,7 @@ meta(AdaBoostClassifier,
 # ============================================================================
 const BaggingRegressor_ = sken(:BaggingRegressor)
 @sk_reg mutable struct BaggingRegressor <: MMI.Deterministic
-    base_estimator::Any      = nothing
+    estimator::Any      = nothing
     n_estimators::Int        = 10::(_>0)
     max_samples::Union{Int,Float64}  = 1.0::(_>0)
     max_features::Union{Int,Float64} = 1.0::(_>0)
@@ -63,7 +63,7 @@ add_human_name_trait(BaggingRegressor, "bagging ensemble regressor")
 # ----------------------------------------------------------------------------
 const BaggingClassifier_ = sken(:BaggingClassifier)
 @sk_clf mutable struct BaggingClassifier <: MMI.Probabilistic
-    base_estimator::Any      = nothing
+    estimator::Any      = nothing
     n_estimators::Int        = 10::(_>0)
     max_samples::Union{Int,Float64}  = 1.0::(_>0)
     max_features::Union{Int,Float64} = 1.0::(_>0)

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -95,11 +95,11 @@ meta(BaggingClassifier,
 # ============================================================================
 const GradientBoostingRegressor_ = sken(:GradientBoostingRegressor)
 @sk_reg mutable struct GradientBoostingRegressor <: MMI.Deterministic
-    loss::String                    = "ls"::(_ in ("ls","lad","huber","quantile"))
+    loss::String                    = "squared_error"::(_ in ("squared_error","absolute_error","huber","quantile"))
     learning_rate::Float64          = 0.1::(_>0)
     n_estimators::Int               = 100::(_>0)
     subsample::Float64              = 1.0::(_>0)
-    criterion::String               = "friedman_mse"::(_ in ("mse","mae","friedman_mse"))
+    criterion::String               = "friedman_mse"::(_ in ("squared_error","friedman_mse"))
     min_samples_split::Union{Int,Float64} = 2::(_>0)
     min_samples_leaf::Union{Int,Float64}  = 1::(_>0)
     min_weight_fraction_leaf::Float64     = 0.0::(_≥0)
@@ -130,7 +130,8 @@ add_human_name_trait(GradientBoostingRegressor, "gradient boosting ensemble regr
 # ----------------------------------------------------------------------------
 const GradientBoostingClassifier_ = sken(:GradientBoostingClassifier)
 @sk_clf mutable struct GradientBoostingClassifier <: MMI.Probabilistic
-    loss::String                    = "deviance"::(_ in ("deviance","exponential"))
+    # TODO: Remove "deviance" when python sklearn releases v1.3.0
+    loss::String                    = "log_loss"::(_ in ("deviance", "log_loss","exponential"))
     learning_rate::Float64          = 0.1::(_>0)
     n_estimators::Int               = 100::(_>0)
     subsample::Float64              = 1.0::(_>0)
@@ -155,6 +156,7 @@ MMI.fitted_params(m::GradientBoostingClassifier, (f, _, _)) = (
     n_estimators        = f.n_estimators_,
     feature_importances = f.feature_importances_,
     train_score         = f.train_score_,
+    ## TODO: Remove the `loss_` attribute when python sklearn releases v1.3
     loss                = f.loss_,
     init                = f.init_,
     estimators          = f.estimators_,
@@ -170,12 +172,13 @@ meta(GradientBoostingClassifier,
 const RandomForestRegressor_ = sken(:RandomForestRegressor)
 @sk_reg mutable struct RandomForestRegressor <: MMI.Deterministic
     n_estimators::Int              = 100::(_ > 0)
-    criterion::String              = "mse"::(_ in ("mae", "mse"))
+    criterion::String              = "squared_error"::(_ in ("squared_error","absolute_error", "friedman_mse", "poisson"))
     max_depth::Option{Int}         = nothing::(_ === nothing || _ > 0)
     min_samples_split::Union{Int,Float64} = 2::(_ > 0)
     min_samples_leaf::Union{Int,Float64}  = 1::(_ > 0)
     min_weight_fraction_leaf::Float64     = 0.0::(_ ≥ 0)
-    max_features::Union{Int,Float64,String,Nothing} = "auto"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || _ > 0)
+    ## TODO: Remove the "auto" option in python sklearn v1.3
+    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || _ > 0)
     max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
     min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
     bootstrap::Bool                = true
@@ -191,7 +194,7 @@ end
 MMI.fitted_params(model::RandomForestRegressor, (f, _, _)) = (
     estimators          = f.estimators_,
     feature_importances = f.feature_importances_,
-    n_features          = f.n_features_,
+    n_features          = f.n_features_in_,
     n_outputs           = f.n_outputs_,
     oob_score           = model.oob_score ? f.oob_score_ : nothing,
     oob_prediction      = model.oob_score ? f.oob_prediction_ : nothing
@@ -206,12 +209,13 @@ meta(RandomForestRegressor,
 const RandomForestClassifier_ = sken(:RandomForestClassifier)
 @sk_clf mutable struct RandomForestClassifier <: MMI.Probabilistic
     n_estimators::Int              = 100::(_ > 0)
-    criterion::String              = "gini"::(_ in ("gini","entropy"))
+    criterion::String              = "gini"::(_ in ("gini","entropy", "log_loss"))
     max_depth::Option{Int}         = nothing::(_ === nothing || _ > 0)
     min_samples_split::Union{Int,Float64} = 2::(_ > 0)
     min_samples_leaf::Union{Int,Float64}  = 1::(_ > 0)
     min_weight_fraction_leaf::Float64     = 0.0::(_ ≥ 0)
-    max_features::Union{Int,Float64,String,Nothing} = "auto"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || _ > 0)
+    ## TODO: Remove the "auto" option in python sklearn v1.3
+    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || _ > 0)
     max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
     min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
     bootstrap::Bool                = true
@@ -229,7 +233,7 @@ MMI.fitted_params(m::RandomForestClassifier, (f, _, _)) = (
     estimators            = f.estimators_,
     classes               = f.classes_,
     n_classes             = f.n_classes_,
-    n_features            = f.n_features_,
+    n_features            = f.n_features_in_,
     n_outputs             = f.n_outputs_,
     feature_importances   = f.feature_importances_,
     oob_score             = m.oob_score ? f.oob_score_ : nothing,
@@ -250,12 +254,13 @@ MMI.target_scitype(::ENSEMBLE_REG) = AbstractVector{Continuous}
 const ExtraTreesRegressor_ = sken(:ExtraTreesRegressor)
 @sk_reg mutable struct ExtraTreesRegressor <: MMI.Deterministic
     n_estimators::Int              = 100::(_>0)
-    criterion::String              = "mse"::(_ in ("mae", "mse"))
+    criterion::String              = "squared_error"::(_ in ("squared_error","absolute_error", "friedman_mse", "poisson"))
     max_depth::Option{Int}         = nothing::(_ === nothing || _ > 0)
     min_samples_split::Union{Int,Float64}  = 2::(_ > 0)
     min_samples_leaf::Union{Int,Float64}   = 1::(_ > 0)
     min_weight_fraction_leaf::Float64      = 0.0::(_ ≥ 0)
-    max_features::Union{Int,Float64,String,Nothing} = "auto"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || _ > 0)
+    ## TODO: Remove the "auto" option in python sklearn v1.3
+    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || _ > 0)
     max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
     min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
     bootstrap::Bool                = true
@@ -268,7 +273,7 @@ end
 MMI.fitted_params(m::ExtraTreesRegressor, (f, _, _)) = (
     estimators          = f.estimators_,
     feature_importances = f.feature_importances_,
-    n_features          = f.n_features_,
+    n_features          = f.n_features_in_,
     n_outputs           = f.n_outputs_,
     oob_score           = m.oob_score ? f.oob_score_ : nothing,
     oob_prediction      = m.oob_score ? f.oob_prediction_ : nothing,
@@ -293,12 +298,13 @@ ExtraTreesRegressor
 const ExtraTreesClassifier_ = sken(:ExtraTreesClassifier)
 @sk_clf mutable struct ExtraTreesClassifier <: MMI.Probabilistic
     n_estimators::Int              = 100::(_>0)
-    criterion::String              = "gini"::(_ in ("gini", "entropy"))
+    criterion::String              = "gini"::(_ in ("gini", "entropy", "log_loss"))
     max_depth::Option{Int}         = nothing::(_ === nothing || _ > 0)
     min_samples_split::Union{Int,Float64}  = 2::(_ > 0)
     min_samples_leaf::Union{Int,Float64}   = 1::(_ > 0)
     min_weight_fraction_leaf::Float64      = 0.0::(_ ≥ 0)
-    max_features::Union{Int,Float64,String,Nothing} = "auto"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || _ > 0)
+    ## TODO: Remove the "auto" option in python sklearn v1.3
+    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || _ > 0)
     max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
     min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
     bootstrap::Bool                = true
@@ -314,7 +320,7 @@ MMI.fitted_params(m::ExtraTreesClassifier, (f, _, _)) = (
     classes               = f.classes_,
     n_classes             = f.n_classes_,
     feature_importances   = f.feature_importances_,
-    n_features            = f.n_features_,
+    n_features            = f.n_features_in_,
     n_outputs             = f.n_outputs_,
     oob_score             = m.oob_score ? f.oob_score_ : nothing,
     oob_decision_function = m.oob_score ? f.oob_decision_function_ : nothing,

--- a/src/models/linear-classifiers.jl
+++ b/src/models/linear-classifiers.jl
@@ -131,7 +131,6 @@ const RidgeClassifier_ = sklm(:RidgeClassifier)
 @sk_clf mutable struct RidgeClassifier <: MMI.Deterministic
     alpha::Float64        = 1.0
     fit_intercept::Bool   = true
-    normalize::Bool       = false
     copy_X::Bool          = true
     max_iter::Option{Int} = nothing::(_ === nothing || _ > 0)
     tol::Float64          = 1e-3::(arg>0)
@@ -155,7 +154,6 @@ const RidgeCVClassifier_ = sklm(:RidgeClassifierCV)
 @sk_clf mutable struct RidgeCVClassifier <: MMI.Deterministic
     alphas::AbstractArray{Float64} = [0.1,1.0,10.0]::(all(0 .≤ _))
     fit_intercept::Bool   = true
-    normalize::Bool       = false
     scoring::Any          = nothing
     cv::Int               = 5
     class_weight::Any     = nothing
@@ -175,7 +173,8 @@ meta(RidgeCVClassifier,
 # ============================================================================
 const SGDClassifier_ = sklm(:SGDClassifier)
 @sk_clf mutable struct SGDClassifier <: MMI.Deterministic
-    loss::String          = "hinge"::(_ in ("hinge", "log", "modified_huber", "squared_hinge", "perceptron", "squared_loss", "huber", "epsilon_insensitive", "squared_epsilon_insensitive"))
+    ## TODO: remove the `log` option when python releases sklearn v1.3.
+    loss::String          = "hinge"::(_ in ("hinge", "log_loss", "log", "modified_huber", "squared_hinge", "perceptron", "squared_error", "huber", "epsilon_insensitive", "squared_epsilon_insensitive"))
     penalty::String       = "l2"::(_ in ("l1", "l2", "elasticnet", "none"))
     alpha::Float64        = 1e-4::(_ > 0)
     l1_ratio::Float64     = 0.15::(0 ≤ _ ≤ 1)
@@ -199,7 +198,8 @@ const SGDClassifier_ = sklm(:SGDClassifier)
 end
 const ProbabilisticSGDClassifier_ = sklm(:SGDClassifier)
 @sk_clf mutable struct ProbabilisticSGDClassifier <: MMI.Probabilistic
-    loss::String          = "log"::(_ in ("log", "modified_huber")) # only those -> predict proba
+    ## TODO: remove the `log` option when python releases sklearn v1.3.
+    loss::String          = "log_loss"::(_ in ("log_loss", "log", "modified_huber")) # only those -> predict proba
     penalty::String       = "l2"::(_ in ("l1", "l2", "elasticnet", "none"))
     alpha::Float64        = 1e-4::(_ > 0)
     l1_ratio::Float64     = 0.15::(0 ≤ _ ≤ 1)

--- a/src/models/linear-regressors-multi.jl
+++ b/src/models/linear-regressors-multi.jl
@@ -2,7 +2,6 @@ const MultiTaskLassoRegressor_ = sklm(:MultiTaskLasso)
 @sk_reg mutable struct MultiTaskLassoRegressor <: MMI.Deterministic
     alpha::Float64      = 1.0::(_ ≥ 0)
     fit_intercept::Bool = true
-    normalize::Bool     = false
     max_iter::Int       = 1_000::(_ > 0)
     tol::Float64        = 1e-4::(_ > 0)
     copy_X::Bool        = true
@@ -22,7 +21,6 @@ const MultiTaskLassoCVRegressor_ = sklm(:MultiTaskLassoCV)
     n_alphas::Int       = 100::(_ > 0)
     alphas::Any         = nothing::(_ === nothing || all(0 .≤ _ .≤ 1))
     fit_intercept::Bool = true
-    normalize::Bool     = false
     max_iter::Int       = 300::(_ > 0)
     tol::Float64        = 1e-4::(_ > 0)
     copy_X::Bool        = true
@@ -47,7 +45,6 @@ const MultiTaskElasticNetRegressor_ = sklm(:MultiTaskElasticNet)
     alpha::Float64      = 1.0::(_ ≥ 0)
     l1_ratio::Union{Float64, Vector{Float64}} = 0.5::(0 ≤ _ ≤ 1)
     fit_intercept::Bool = true
-    normalize::Bool     = true
     copy_X::Bool        = true
     max_iter::Int       = 1_000::(_ > 0)
     tol::Float64        = 1e-4::(_ > 0)
@@ -69,7 +66,6 @@ const MultiTaskElasticNetCVRegressor_ = sklm(:MultiTaskElasticNetCV)
     n_alphas::Int       = 100::(_ > 0)
     alphas::Any         = nothing::(_ === nothing || all(0 .≤ _ .≤ 1))
     fit_intercept::Bool = true
-    normalize::Bool     = false
     max_iter::Int       = 1_000::(_ > 0)
     tol::Float64        = 1e-4::(_ > 0)
     cv::Any             = 5

--- a/src/models/linear-regressors.jl
+++ b/src/models/linear-regressors.jl
@@ -9,7 +9,6 @@ const ARDRegressor_ = sklm(:ARDRegression)
     compute_score::Bool       = false
     threshold_lambda::Float64 = 1e4::(_ > 0)
     fit_intercept::Bool       = true
-    normalize::Bool           = false
     copy_X::Bool              = true
     verbose::Bool             = false
 end
@@ -34,7 +33,6 @@ const BayesianRidgeRegressor_ = sklm(:BayesianRidge)
     lambda_2::Float64   = 1e-6::(_ > 0)
     compute_score::Bool = false
     fit_intercept::Bool = true
-    normalize::Bool     = false
     copy_X::Bool        = true
     verbose::Bool       = false
 end
@@ -54,7 +52,6 @@ const ElasticNetRegressor_ = sklm(:ElasticNet)
     alpha::Float64      = 1.0::(_ ≥ 0)   # 0 is OLS
     l1_ratio::Float64   = 0.5::(0 ≤ _ ≤ 1)
     fit_intercept::Bool = true
-    normalize::Bool     = false
     precompute::Union{Bool,AbstractMatrix} = false
     max_iter::Int       = 1_000::(_ ≥ 1)
     copy_X::Bool        = true
@@ -77,7 +74,6 @@ const ElasticNetCVRegressor_ = sklm(:ElasticNetCV)
     n_alphas::Int       = 100::(_ > 0)
     alphas::Any         = nothing::(_ === nothing || all(0 .≤ _))
     fit_intercept::Bool = true
-    normalize::Bool     = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     max_iter::Int       = 1_000::(_ > 0)
     tol::Float64        = 1e-4::(_ > 0)
@@ -121,7 +117,8 @@ const LarsRegressor_ = sklm(:Lars)
 @sk_reg mutable struct LarsRegressor <: MMI.Deterministic
     fit_intercept::Bool      = true
     verbose::Union{Bool,Int} = false
-    normalize::Bool          = true
+    # TODO Remove this when python ScikitLearn releases v1.4
+    normalize::Bool          = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     n_nonzero_coefs::Int     = 500::(_ > 0)
     eps::Float64   = eps(Float64)::(_ > 0)
@@ -143,7 +140,8 @@ const LarsCVRegressor_ = sklm(:LarsCV)
     fit_intercept::Bool      = true
     verbose::Union{Bool,Int} = false
     max_iter::Int     = 500::(_ > 0)
-    normalize::Bool   = true
+    # TODO Remove this when python ScikitLearn releases v1.4
+    normalize::Bool   = false 
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     cv::Any           = 5
     max_n_alphas::Int = 1_000::(_ > 0)
@@ -167,7 +165,6 @@ const LassoRegressor_ = sklm(:Lasso)
 @sk_reg mutable struct LassoRegressor <: MMI.Deterministic
     alpha::Float64      = 1.0::(_ ≥ 0) # should use alpha > 0 (or OLS)
     fit_intercept::Bool = true
-    normalize::Bool     = false
     precompute::Union{Bool,AbstractMatrix} = false
     copy_X::Bool        = true
     max_iter::Int       = 1_000::(_ > 0)
@@ -189,7 +186,6 @@ const LassoCVRegressor_ = sklm(:LassoCV)
     n_alphas::Int       = 100::(_ > 0)
     alphas::Any         = nothing::(_ === nothing || all(0 .≤ _))
     fit_intercept::Bool = true
-    normalize::Bool     = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     max_iter::Int       = 1_000::(_ > 0)
     tol::Float64        = 1e-4::(_ > 0)
@@ -217,7 +213,8 @@ const LassoLarsRegressor_ = sklm(:LassoLars)
     alpha::Float64      = 1.0::(_ ≥ 0) # 0 should be OLS
     fit_intercept::Bool = true
     verbose::Union{Bool, Int} = false
-    normalize::Bool     = true
+    # TODO Remove this when python ScikitLearn releases v1.4
+    normalize::Bool     = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     max_iter::Int       = 500::(_ > 0)
     eps::Float64        = eps(Float64)::(_ > 0)
@@ -240,7 +237,8 @@ const LassoLarsCVRegressor_ = sklm(:LassoLarsCV)
     fit_intercept::Bool = true
     verbose::Union{Bool, Int} = false
     max_iter::Int       = 500::(_ > 0)
-    normalize::Bool     = true
+    # TODO Remove this when python ScikitLearn releases v1.4
+    normalize::Bool     = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     cv::Any             = 5
     max_n_alphas::Int   = 1_000::(_ > 0)
@@ -267,7 +265,8 @@ const LassoLarsICRegressor_ = sklm(:LassoLarsIC)
     criterion::String   = "aic"::(_ in ("aic","bic"))
     fit_intercept::Bool = true
     verbose::Union{Bool, Int} = false
-    normalize::Bool     = true
+    # TODO Remove this when python ScikitLearn releases v1.4
+    normalize::Bool     = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     max_iter::Int       = 500::(_ > 0)
     eps::Float64        = eps(Float64)::(_ > 0.0)
@@ -286,7 +285,6 @@ add_human_name_trait(LassoLarsICRegressor, "Lasso model with LARS using "*
 const LinearRegressor_ = sklm(:LinearRegression)
 @sk_reg mutable struct LinearRegressor <: MMI.Deterministic
     fit_intercept::Bool = true
-    normalize::Bool     = false
     copy_X::Bool        = true
     n_jobs::Option{Int} = nothing
 end
@@ -302,7 +300,7 @@ const OrthogonalMatchingPursuitRegressor_ = sklm(:OrthogonalMatchingPursuit)
     n_nonzero_coefs::Option{Int} = nothing
     tol::Option{Float64} = nothing
     fit_intercept::Bool  = true
-    normalize::Bool      = true
+    normalize::Bool      = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
 end
 MMI.fitted_params(model::OrthogonalMatchingPursuitRegressor, (fitresult, _, _)) = (
@@ -315,6 +313,7 @@ const OrthogonalMatchingPursuitCVRegressor_ = sklm(:OrthogonalMatchingPursuitCV)
 @sk_reg mutable struct OrthogonalMatchingPursuitCVRegressor <: MMI.Deterministic
     copy::Bool            = true
     fit_intercept::Bool   = true
+    # TODO Remove this when python ScikitLearn releases v1.4
     normalize::Bool       = false
     max_iter::Option{Int} = nothing::(_ === nothing||_ > 0)
     cv::Any               = 5
@@ -355,7 +354,7 @@ MMI.fitted_params(model::PassiveAggressiveRegressor, (fitresult, _, _)) = (
 # =============================================================================
 const RANSACRegressor_ = sklm(:RANSACRegressor)
 @sk_reg mutable struct RANSACRegressor <: MMI.Deterministic
-    base_estimator::Any         = nothing
+    estimator::Any         = nothing
     min_samples::Union{Int,Float64}     = 5::(_ isa Int ? _ ≥ 1 : (0 ≤ _ ≤ 1))
     residual_threshold::Option{Float64} = nothing
     is_data_valid::Any          = nothing
@@ -365,7 +364,7 @@ const RANSACRegressor_ = sklm(:RANSACRegressor)
     stop_n_inliers::Int         = typemax(Int)::(_ > 0)
     stop_score::Float64         = Inf::(_ > 0)
     stop_probability::Float64   = 0.99::(0 ≤ _ ≤ 1.0)
-    loss::Union{Function,String}= "absolute_loss"::((_ isa Function) || _ in ("absolute_loss","squared_loss"))
+    loss::Union{Function,String}= "absolute_error"::((_ isa Function) || _ in ("absolute_error","squared_error"))
     random_state::Any           = nothing
 end
 MMI.fitted_params(m::RANSACRegressor, (f, _, _)) = (
@@ -382,7 +381,6 @@ const RidgeRegressor_ = sklm(:Ridge)
 @sk_reg mutable struct RidgeRegressor <: MMI.Deterministic
     alpha::Union{Float64,Vector{Float64}} = 1.0::(all(_ .> 0))
     fit_intercept::Bool = true
-    normalize::Bool     = false
     copy_X::Bool        = true
     max_iter::Int       = 1_000::(_ > 0)
     tol::Float64        = 1e-4::(_ > 0)
@@ -399,7 +397,6 @@ const RidgeCVRegressor_ = sklm(:RidgeCV)
 @sk_reg mutable struct RidgeCVRegressor <: MMI.Deterministic
     alphas::Any              = (0.1, 1.0, 10.0)::(all(_ .> 0))
     fit_intercept::Bool      = true
-    normalize::Bool          = false
     scoring::Any             = nothing
     cv::Any                  = 5
     gcv_mode::Option{String} = nothing::(_ === nothing || _ in ("auto","svd","eigen"))
@@ -416,7 +413,7 @@ add_human_name_trait(RidgeCVRegressor, "ridge regressor $CV")
 # =============================================================================
 const SGDRegressor_ = sklm(:SGDRegressor)
 @sk_reg mutable struct SGDRegressor <: MMI.Deterministic
-    loss::String             = "squared_loss"::(_ in ("squared_loss","huber","epsilon_insensitive","squared_epsilon_insensitive"))
+    loss::String             = "squared_error"::(_ in ("squared_error","huber","epsilon_insensitive","squared_epsilon_insensitive"))
     penalty::String          = "l2"::(_ in ("none","l2","l1","elasticnet"))
     alpha::Float64           = 1e-4::(_ > 0)
     l1_ratio::Float64        = 0.15::(_ > 0)


### PR DESCRIPTION
At the time of opening the PR the latest version of python's scikitlearn is v1.2.1. In line with this new version the following changes have been made.

1. The `normalize` parameter have been removed from the following linear models

- `ARDRegressor`
- `BayesianRidgeRegressor`
- `ElasticNetRegressor`
- `ElasticNetCVRegressor`
- `LassoRegressor`
- `LassoCVRegressor`
- `LinearRegressor`
- `MultiTaskElasticNetRegressor`
- `MultiTaskElasticNetCVRegressor`
- `MultiTaskLassoRegressor`
- `MultiTaskLassoCVRegressor`
- `RidgeCVClassifier`
- `RidgeClassifier`

2. The `normalize` parameter of the following linear models has been set as `false`, but will be removed when python scikitlearn v1.4 is released. 
- `OrthogonalMatchingPursuitRegressor`
- `OrthogonalMatchingPursuitCVRegressor`
-  `LarsRegressor`
- `LarsCVRegressor`
- `LassoLarsCVRegressor`
- `LassoLarsICRegressor`

3. The `base_estimator` parameter in `AdaBoostRegressor`, `AdaboostClassifier`, `BaggingRegressor`, `BaggingClassifier` and `RANSACRegressor` models has been renamed to `estimator`.

4. The `absolute_loss` and `squared_loss` losses has been replaced by the equivalent
`absolute_error` and `squared_error` respectively.

5. Depreciate the `auto` option for `max_features` in `RandomForestRegressor`, `RandomForestClassifier`, `ExtraTreesRegressor` and `ExtraTreesClassifier` models. The new default for `max_features` has been set to
`sqrt`.
6. Replace the `ls` loss with the equivalent `squared_loss` error. Set the default value of `loss` parameter in the `GradientBoostingRegressor` model to `squared_loss`
7. Default value for `criterion` in `RandomForestRegressor`and `ExtrasTreesRegressor` models has been set to `squared_loss`. New losses such as `friedman_mse` and `poisson` has been added to the list of possible options for `criterion`
8. `log_loss` has been added to the list of possible option for the `criterion` parameter in `RandomForestClassifier` and `ExtrasTreesClassifier` models.
9. The `lad` loss in the `GradientBoostingRegressor` model has been replaced by the equivalent `absolute_error` loss
Additionally
- The `mae` loss was removed from the possible options for the `criterion`parameter
- The `mse` was replaced with the equivaled `squared_error` and, 
- The `friedman_mse` was added to the possible options for the `criterion` parameter.
10. Add the `"log_loss"` loss as one of the possible options to the `loss` parameter in the `ProbalisticSGDClassifier`and `SGDClassifier` models.
11. Change the default value of `loss` parameter in `ProbalisticSGDClassifier` model from `"log"` to `"log_loss"`.
12. Change the default value of `algorithm` parameter in `KMeans` model from `"auto"` to `"lloyd"`.
 
see https://scikit-learn.org/stable/whats_new/v1.0.html#changes-1-0 and
https://scikit-learn.org/stable/whats_new/v1.0.html