### PR TITLE
scikit-learn `v1.3` support

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,4 +1,4 @@
 
 [deps.scikit-learn]
 channel = "conda-forge"
-version = ">=1.2, <1.3"
+version = ">=1.2, <1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJScikitLearnInterface"
 uuid = "5ae90465-5518-4432-b9d2-8a1def2f0cab"
 authors = ["Thibaut Lienart, Anthony Blaom"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/src/MLJScikitLearnInterface.jl
+++ b/src/MLJScikitLearnInterface.jl
@@ -10,12 +10,6 @@ include("ScikitLearnAPI.jl")
 const SK = ScikitLearnAPI
 import PythonCall: pyisnull, PyNULL, pyimport, pycopy!, pynew, pyconvert
 
-# ------------------------------------------------------------------------
-# NOTE: the next few lines of wizardry and their call should not be
-# modified carelessly. In particular do consider the recommendations at
-# JuliaPy/PyCall.jl#using-pycall-from-julia-modules
-# from which much of this stems.
-
 # supervised
 const SKLM = pynew()
 const SKGP = pynew()

--- a/src/models/clustering.jl
+++ b/src/models/clustering.jl
@@ -189,8 +189,7 @@ const KMeans_ = skcl(:KMeans)
     verbose::Int        = 0::(_ ≥ 0)
     random_state::Any   = nothing
     copy_x::Bool        = true
-    ## TODO: Remove the "auto" and "full" options when python sklearn releases v1.3
-    algorithm::String   = "lloyd"::(_ in ("auto", "full", "elkane", "lloyd"))
+    algorithm::String   = "lloyd"::(_ in ("elkane", "lloyd"))
     # long
     init::Union{AbstractArray,String}        = "k-means++"::(_ isa AbstractArray || _ in ("k-means++", "random"))
 end

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -123,8 +123,6 @@ end
 MMI.fitted_params(m::GradientBoostingRegressor, (f, _, _)) = (
     feature_importances = f.feature_importances_,
     train_score         = f.train_score_,
-    # remove `loss` parameter when python sklearn releases v1.3
-    loss                = f.loss_,
     init                = f.init_,
     estimators          = f.estimators_,
     oob_improvement     = m.subsample < 1 ? f.oob_improvement_ : nothing
@@ -134,8 +132,7 @@ add_human_name_trait(GradientBoostingRegressor, "gradient boosting ensemble regr
 # ----------------------------------------------------------------------------
 const GradientBoostingClassifier_ = sken(:GradientBoostingClassifier)
 @sk_clf mutable struct GradientBoostingClassifier <: MMI.Probabilistic
-    # TODO: Remove "deviance" when python sklearn releases v1.3.0
-    loss::String                    = "log_loss"::(_ in ("deviance", "log_loss","exponential"))
+    loss::String                    = "log_loss"::(_ in ("log_loss","exponential"))
     learning_rate::Float64          = 0.1::(_>0)
     n_estimators::Int               = 100::(_>0)
     subsample::Float64              = 1.0::(_>0)
@@ -160,8 +157,6 @@ MMI.fitted_params(m::GradientBoostingClassifier, (f, _, _)) = (
     n_estimators        = f.n_estimators_,
     feature_importances = f.feature_importances_,
     train_score         = f.train_score_,
-    ## TODO: Remove the `loss_` attribute when python sklearn releases v1.3
-    loss                = f.loss_,
     init                = f.init_,
     estimators          = f.estimators_,
     oob_improvement     = m.subsample < 1 ? f.oob_improvement_ : nothing
@@ -181,8 +176,7 @@ const RandomForestRegressor_ = sken(:RandomForestRegressor)
     min_samples_split::Union{Int,Float64} = 2::(_ > 0)
     min_samples_leaf::Union{Int,Float64}  = 1::(_ > 0)
     min_weight_fraction_leaf::Float64     = 0.0::(_ ≥ 0)
-    ## TODO: Remove the "auto" option in python sklearn v1.3
-    max_features::Union{Int,Float64,String,Nothing} = 1.0::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || (_ isa Number && _ > 0))
+    max_features::Union{Int,Float64,String,Nothing} = 1.0::(_ === nothing || (isa(_, String) && (_ in ("sqrt","log2"))) || (_ isa Number && _ > 0))
     max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
     min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
     bootstrap::Bool                = true
@@ -219,8 +213,7 @@ const RandomForestClassifier_ = sken(:RandomForestClassifier)
     min_samples_split::Union{Int,Float64} = 2::(_ > 0)
     min_samples_leaf::Union{Int,Float64}  = 1::(_ > 0)
     min_weight_fraction_leaf::Float64     = 0.0::(_ ≥ 0)
-    ## TODO: Remove the "auto" option in python sklearn v1.3
-    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || (_ isa Number && _ > 0))
+    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("sqrt","log2"))) || (_ isa Number && _ > 0))
     max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
     min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
     bootstrap::Bool                = true
@@ -265,8 +258,7 @@ const ExtraTreesRegressor_ = sken(:ExtraTreesRegressor)
     min_samples_split::Union{Int,Float64}  = 2::(_ > 0)
     min_samples_leaf::Union{Int,Float64}   = 1::(_ > 0)
     min_weight_fraction_leaf::Float64      = 0.0::(_ ≥ 0)
-    ## TODO: Remove the "auto" option in python sklearn v1.3
-    max_features::Union{Int,Float64,String,Nothing} = 1.0::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || (_ isa Number && _ > 0))
+    max_features::Union{Int,Float64,String,Nothing} = 1.0::(_ === nothing || (isa(_, String) && (_ in ("sqrt","log2"))) || (_ isa Number && _ > 0))
     max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
     min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
     bootstrap::Bool                = true
@@ -310,8 +302,7 @@ const ExtraTreesClassifier_ = sken(:ExtraTreesClassifier)
     min_samples_split::Union{Int,Float64}  = 2::(_ > 0)
     min_samples_leaf::Union{Int,Float64}   = 1::(_ > 0)
     min_weight_fraction_leaf::Float64      = 0.0::(_ ≥ 0)
-    ## TODO: Remove the "auto" option in python sklearn v1.3
-    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("auto","sqrt","log2"))) || (_ isa Number && _ > 0))
+    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("sqrt","log2"))) || (_ isa Number && _ > 0))
     max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
     min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
     bootstrap::Bool                = true

--- a/src/models/linear-classifiers.jl
+++ b/src/models/linear-classifiers.jl
@@ -173,8 +173,7 @@ meta(RidgeCVClassifier,
 # ============================================================================
 const SGDClassifier_ = sklm(:SGDClassifier)
 @sk_clf mutable struct SGDClassifier <: MMI.Deterministic
-    ## TODO: remove the `log` option when python releases sklearn v1.3.
-    loss::String          = "hinge"::(_ in ("hinge", "log_loss", "log", "modified_huber", "squared_hinge", "perceptron", "squared_error", "huber", "epsilon_insensitive", "squared_epsilon_insensitive"))
+    loss::String          = "hinge"::(_ in ("hinge", "log_loss", "modified_huber", "squared_hinge", "perceptron", "squared_error", "huber", "epsilon_insensitive", "squared_epsilon_insensitive"))
     penalty::String       = "l2"::(_ in ("l1", "l2", "elasticnet", "none"))
     alpha::Float64        = 1e-4::(_ > 0)
     l1_ratio::Float64     = 0.15::(0 ≤ _ ≤ 1)
@@ -198,8 +197,7 @@ const SGDClassifier_ = sklm(:SGDClassifier)
 end
 const ProbabilisticSGDClassifier_ = sklm(:SGDClassifier)
 @sk_clf mutable struct ProbabilisticSGDClassifier <: MMI.Probabilistic
-    ## TODO: remove the `log` option when python releases sklearn v1.3.
-    loss::String          = "log_loss"::(_ in ("log_loss", "log", "modified_huber")) # only those -> predict proba
+    loss::String          = "log_loss"::(_ in ("log_loss", "modified_huber")) # only those -> predict proba
     penalty::String       = "l2"::(_ in ("l1", "l2", "elasticnet", "none"))
     alpha::Float64        = 1e-4::(_ > 0)
     l1_ratio::Float64     = 0.15::(0 ≤ _ ≤ 1)

--- a/src/models/linear-regressors.jl
+++ b/src/models/linear-regressors.jl
@@ -1,5 +1,6 @@
 const ARDRegressor_ = sklm(:ARDRegression)
 @sk_reg mutable struct ARDRegressor <: MMI.Deterministic
+    # TODO: rename `n_iter` to `max_iter` in v1.5
     n_iter::Int               = 300::(_ > 0)
     tol::Float64              = 1e-3::(_ > 0)
     alpha_1::Float64          = 1e-6::(_ > 0)
@@ -25,6 +26,7 @@ add_human_name_trait(ARDRegressor, "Bayesian ARD regressor")
 # =============================================================================
 const BayesianRidgeRegressor_ = sklm(:BayesianRidge)
 @sk_reg mutable struct BayesianRidgeRegressor <: MMI.Deterministic
+    # TODO: rename `n_iter` to `max_iter` in v1.5
     n_iter::Int         = 300::(_ ≥ 1)
     tol::Float64        = 1e-3::(_ > 0)
     alpha_1::Float64    = 1e-6::(_ > 0)

--- a/test/models/ensemble.jl
+++ b/test/models/ensemble.jl
@@ -9,7 +9,7 @@ models = (
 fparams = (
     AdaBoostClassifier=(:estimator, :estimators, :estimator_weights, :estimator_errors, :classes, :n_classes),
     BaggingClassifier=(:estimator, :estimators, :estimators_samples, :estimators_features, :classes, :n_classes, :oob_score, :oob_decision_function),
-    GradientBoostingClassifier=(:n_estimators, :feature_importances, :train_score, :loss, :init, :estimators, :oob_improvement),
+    GradientBoostingClassifier=(:n_estimators, :feature_importances, :train_score, :init, :estimators, :oob_improvement),
     RandomForestClassifier=(:estimator, :estimators, :classes, :n_classes, :n_features, :n_outputs, :feature_importances, :oob_score, :oob_decision_function),
     ExtraTreesClassifier=(:estimator, :estimators, :classes, :n_classes, :feature_importances, :n_features, :n_outputs, :oob_score, :oob_decision_function)
 )
@@ -42,7 +42,7 @@ models = (
 fparams = (
     AdaBoostRegressor=(:estimator, :estimators, :estimator_weights, :estimator_errors, :feature_importances),
     BaggingRegressor=(:estimator, :estimators, :estimators_samples, :estimators_features, :oob_score, :oob_prediction),
-    GradientBoostingRegressor=(:feature_importances, :train_score, :loss, :init, :estimators, :oob_improvement),
+    GradientBoostingRegressor=(:feature_importances, :train_score, :init, :estimators, :oob_improvement),
     RandomForestRegressor=(:estimator, :estimators, :feature_importances, :n_features, :n_outputs, :oob_score, :oob_prediction),
     ExtraTreesRegressor=(:estimator, :estimators, :feature_importances, :n_features, :n_outputs, :oob_score, :oob_prediction)
 )


### PR DESCRIPTION
I have removed all the items that were removed from `scikit-learn@v1.3` and added two comments for removing `n_iter` for linear models in `v1.5`. 

I also removed a comment about using `PyCall.jl` that was leftover from before the transition.

At some point, we should also expand the model support to include newer `scikit-learn` additions such as `HistGradientBoostingClassifier`. 

[`v1.3.0` Patch Notes](https://scikit-learn.org/stable/whats_new/v1.3.html)