### PR TITLE
New models, automatically convert more fit results, and support for feature importances

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,15 +8,18 @@ MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
+MLJBase = "=1"
 MLJModelInterface = "1.4"
 PythonCall = "0.9"
+StatisticalMeasures = "0.1"
 julia = "1.6"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJTestInterface = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+StatisticalMeasures = "a19d573c-0a75-4610-95b3-7071388c7541"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StableRNGs", "MLJTestInterface", "Test", "MLJBase"]
+test = ["MLJBase", "MLJTestInterface", "StableRNGs", "StatisticalMeasures", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
-MLJBase = "=1"
+MLJBase = "1"
 MLJModelInterface = "1.4"
 PythonCall = "0.9"
 StatisticalMeasures = "0.1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Thibaut Lienart, Anthony Blaom"]
 version = "0.5.0"
 
 [deps]
-MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,14 @@ version = "0.5.0"
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 MLJBase = "1"
 MLJModelInterface = "1.4"
 PythonCall = "0.9"
 StatisticalMeasures = "0.1"
+Tables = "1.10"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ authors = ["Thibaut Lienart, Anthony Blaom"]
 version = "0.5.0"
 
 [deps]
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJScikitLearnInterface"
 uuid = "5ae90465-5518-4432-b9d2-8a1def2f0cab"
 authors = ["Thibaut Lienart, Anthony Blaom"]
-version = "0.5.0"
+version = "0.6.0"
 
 [deps]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Thibaut Lienart, Anthony Blaom"]
 version = "0.5.0"
 
 [deps]
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
@@ -12,7 +13,6 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 MLJBase = "1"
 MLJModelInterface = "1.4"
 PythonCall = "0.9"
-StatisticalMeasures = "0.1"
 Tables = "1.10"
 julia = "1.6"
 
@@ -20,8 +20,7 @@ julia = "1.6"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJTestInterface = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
-StatisticalMeasures = "a19d573c-0a75-4610-95b3-7071388c7541"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["MLJBase", "MLJTestInterface", "StableRNGs", "StatisticalMeasures", "Test"]
+test = ["MLJBase", "MLJTestInterface", "StableRNGs", "Test"]

--- a/src/MLJScikitLearnInterface.jl
+++ b/src/MLJScikitLearnInterface.jl
@@ -5,6 +5,7 @@ import MLJModelInterface:
         @mlj_model, _process_model_def, _model_constructor, _model_cleaner,
         Table, Continuous, Count, Finite, OrderedFactor, Multiclass, Unknown
 const MMI = MLJModelInterface
+using Statistics
 import Tables
 
 include("ScikitLearnAPI.jl")

--- a/src/MLJScikitLearnInterface.jl
+++ b/src/MLJScikitLearnInterface.jl
@@ -5,6 +5,7 @@ import MLJModelInterface:
         @mlj_model, _process_model_def, _model_constructor, _model_cleaner,
         Table, Continuous, Count, Finite, OrderedFactor, Multiclass, Unknown
 const MMI = MLJModelInterface
+import Tables
 
 include("ScikitLearnAPI.jl")
 const SK = ScikitLearnAPI
@@ -49,6 +50,7 @@ const CV = "with built-in cross-validation"
 
 include("macros.jl")
 include("meta.jl")
+include("tables.jl")
 
 include("models/linear-regressors.jl")
 include("models/linear-regressors-multi.jl")

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -329,3 +329,18 @@ macro sku_predict(modelname)
         end
     end
 end
+
+"""
+    macro sk_feature_importances(modelname)
+
+Adds a `feature_importance` method to a declared scikit model if
+there is one supported.
+"""
+macro sk_feature_importances(modelname)
+    quote
+        MMI.reports_feature_importances(::Type{<:$modelname}) = true
+        function MMI.feature_importances(::$modelname, (f, _), r)
+            result = [(i => x) for (i, x) in enumerate(f.feature_importances)]
+        end
+    end
+end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -339,8 +339,9 @@ there is one supported.
 macro sk_feature_importances(modelname)
     quote
         MMI.reports_feature_importances(::Type{<:$modelname}) = true
-        function MMI.feature_importances(::$modelname, (f, _), r)
-            result = [(r[i] => x) for (i, x) in enumerate(f.feature_importances)]
+        function MMI.feature_importances(m::$modelname, fitres, r)
+            params = MMI.fitted_params(m, fitres)
+            result = [(r.names[i] => x) for (i, x) in enumerate(params.feature_importances)]
         end
     end
 end

--- a/src/models/clustering.jl
+++ b/src/models/clustering.jl
@@ -170,10 +170,10 @@ meta(HDBSCAN,
 $(MMI.doc_header(HDBSCAN))
 
 Hierarchical Density-Based Spatial Clustering of Applications with 
-Noise. Performs [`DBSCAN'](@ref) over varying epsilon values and 
+Noise. Performs [`DBSCAN`](@ref) over varying epsilon values and 
 integrates the result to find a clustering that gives the best 
 stability over epsilon. This allows HDBSCAN to find clusters of 
-varying densities (unlike [`DBSCAN'](@ref)), and be more robust to 
+varying densities (unlike [`DBSCAN`](@ref)), and be more robust to 
 parameter selection. 
 
 """

--- a/src/models/discriminant-analysis.jl
+++ b/src/models/discriminant-analysis.jl
@@ -9,15 +9,15 @@ const BayesianLDA_ = skda(:LinearDiscriminantAnalysis)
     covariance_estimator::Any        = nothing
 end
 MMI.fitted_params(m::BayesianLDA, (f, _, _)) = (
-    coef       = f.coef_,
-    intercept  = f.intercept_,
-    covariance = m.store_covariance ? f.covariance_ : nothing,
-    means      = f.means_,
-    priors     = f.priors_,
-    scalings   = f.scalings_,
-    xbar       = f.xbar_,
-    classes    = f.classes_,
-    explained_variance_ratio = f.explained_variance_ratio_
+    coef       = pyconvert(Array, f.coef_),
+    intercept  = pyconvert(Array, f.intercept_),
+    covariance = m.store_covariance ? pyconvert(Array, f.covariance_) : nothing,
+    explained_variance_ratio = pyconvert(Array, f.explained_variance_ratio_),
+    means      = pyconvert(Array, f.means_),
+    priors     = pyconvert(Array, f.priors_),
+    scalings   = pyconvert(Array, f.scalings_),
+    xbar       = pyconvert(Array, f.xbar_),
+    classes    = pyconvert(Array, f.classes_)
     )
 meta(BayesianLDA,
     input   = Table(Continuous),
@@ -35,11 +35,11 @@ const BayesianQDA_ = skda(:QuadraticDiscriminantAnalysis)
     tol::Float64                   = 1e-4::(_ > 0)
 end
 MMI.fitted_params(m::BayesianQDA, (f, _, _)) = (
-    covariance = m.store_covariance ? f.covariance_ : nothing,
-    means      = f.means_,
-    priors     = f.priors_,
-    rotations  = f.rotations_,
-    scalings   = f.scalings_
+    covariance = m.store_covariance ? pyconvert(Array, f.covariance_) : nothing,
+    means      = pyconvert(Array, f.means_),
+    priors     = pyconvert(Array, f.priors_),
+    rotations  = pyconvert(Array, f.rotations_),
+    scalings   = pyconvert(Array, f.scalings_),
     )
 meta(BayesianQDA,
     input   = Table(Continuous),

--- a/src/models/discriminant-analysis.jl
+++ b/src/models/discriminant-analysis.jl
@@ -25,6 +25,7 @@ meta(BayesianLDA,
     weights = false,
     human_name   = "Bayesian linear discriminant analysis"
     )
+@sk_feature_importances BayesianLDA
 
 # ============================================================================
 const BayesianQDA_ = skda(:QuadraticDiscriminantAnalysis)

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -9,9 +9,9 @@ end
 MMI.fitted_params(model::AdaBoostRegressor, (f, _, _)) = (
     estimator            = f.estimator_,
     estimators           = f.estimators_,
-    estimator_weights    = f.estimator_weights_,
-    estimator_errors     = f.estimator_errors_,
-    feature_importances  = f.feature_importances_
+    estimator_weights    = pyconvert(Array, f.estimator_weights_),
+    estimator_errors     = pyconvert(Array, f.estimator_errors_),
+    feature_importances  = pyconvert(Array, f.feature_importances_)
     )
 add_human_name_trait(AdaBoostRegressor, "AdaBoost ensemble regression")
 """
@@ -41,10 +41,10 @@ end
 MMI.fitted_params(m::AdaBoostClassifier, (f, _, _)) = (
     estimator         = f.estimator_,
     estimators        = f.estimators_,
-    estimator_weights = f.estimator_weights_,
-    estimator_errors  = f.estimator_errors_,
-    classes           = f.classes_,
-    n_classes         = f.n_classes_
+    estimator_weights = pyconvert(Array, f.estimator_weights_),
+    estimator_errors  = pyconvert(Array, f.estimator_errors_),
+    classes           = pyconvert(Array, f.classes_),
+    n_classes         = pyconvert(Int, f.n_classes_)
     )
 meta(AdaBoostClassifier,
     input   = Table(Continuous),
@@ -85,8 +85,8 @@ MMI.fitted_params(model::BaggingRegressor, (f, _, _)) = (
     estimators          = f.estimators_,
     estimators_samples  = f.estimators_samples_,
     estimators_features = f.estimators_features_,
-    oob_score           = model.oob_score ? f.oob_score_ : nothing,
-    oob_prediction      = model.oob_score ? f.oob_prediction_ : nothing
+    oob_score           = model.oob_score ? pyconvert(Float64, f.oob_score_) : nothing,
+    oob_prediction      = model.oob_score ? pyconvert(Array, f.oob_prediction_) : nothing
     )
 add_human_name_trait(BaggingRegressor, "bagging ensemble regressor")
 """
@@ -124,9 +124,9 @@ MMI.fitted_params(m::BaggingClassifier, (f, _, _)) = (
     estimators            = f.estimators_,
     estimators_samples    = f.estimators_samples_,
     estimators_features   = f.estimators_features_,
-    classes               = f.classes_,
-    n_classes             = f.n_classes_,
-    oob_score             = m.oob_score ? f.oob_score_ : nothing,
+    classes               = pyconvert(Array, f.classes_),
+    n_classes             = pyconvert(Int, f.n_classes_),
+    oob_score             = m.oob_score ? pyconvert(Float64, f.oob_score_) : nothing,
     oob_decision_function = m.oob_score ? f.oob_decision_function_ : nothing
     )
 meta(BaggingClassifier,
@@ -171,11 +171,11 @@ end
 MMI.fitted_params(m::ExtraTreesRegressor, (f, _, _)) = (
     estimator           = f.estimator_,
     estimators          = f.estimators_,
-    feature_importances = f.feature_importances_,
-    n_features          = f.n_features_in_,
-    n_outputs           = f.n_outputs_,
-    oob_score           = m.oob_score ? f.oob_score_ : nothing,
-    oob_prediction      = m.oob_score ? f.oob_prediction_ : nothing,
+    feature_importances = pyconvert(Array, f.feature_importances_),
+    n_features          = pyconvert(Int, f.n_features_in_),
+    n_outputs           = pyconvert(Int, f.n_outputs_),
+    oob_score           = m.oob_score ? pyconvert(Float64, f.oob_score_) : nothing,
+    oob_prediction      = m.oob_score ? pyconvert(Array, f.oob_prediction_) : nothing,
     )
 meta(ExtraTreesRegressor,
     input   = Table(Continuous),
@@ -216,12 +216,12 @@ end
 MMI.fitted_params(m::ExtraTreesClassifier, (f, _, _)) = (
     estimator             = f.estimator_,
     estimators            = f.estimators_,
-    classes               = f.classes_,
-    n_classes             = f.n_classes_,
-    feature_importances   = f.feature_importances_,
-    n_features            = f.n_features_in_,
-    n_outputs             = f.n_outputs_,
-    oob_score             = m.oob_score ? f.oob_score_ : nothing,
+    classes               = pyconvert(Array, f.classes_),
+    n_classes             = pyconvert(Int, f.n_classes_),
+    feature_importances   = pyconvert(Array, f.feature_importances_),
+    n_features            = pyconvert(Int, f.n_features_in_),
+    n_outputs             = pyconvert(Int, f.n_outputs_),
+    oob_score             = m.oob_score ? pyconvert(Float64, f.oob_score_) : nothing,
     oob_decision_function = m.oob_score ? f.oob_decision_function_ : nothing,
     )
 meta(ExtraTreesClassifier,
@@ -266,11 +266,11 @@ const GradientBoostingRegressor_ = sken(:GradientBoostingRegressor)
     tol::Float64                   = 1e-4::(_>0)
 end
 MMI.fitted_params(m::GradientBoostingRegressor, (f, _, _)) = (
-    feature_importances = f.feature_importances_,
-    train_score         = f.train_score_,
+    feature_importances = pyconvert(Array, f.feature_importances_),
+    train_score         = pyconvert(Array, f.train_score_),
     init                = f.init_,
     estimators          = f.estimators_,
-    oob_improvement     = m.subsample < 1 ? f.oob_improvement_ : nothing
+    oob_improvement     = m.subsample < 1 ? pyconvert(Array, f.oob_improvement_) : nothing
     )
 add_human_name_trait(GradientBoostingRegressor, "gradient boosting ensemble regression")
 """
@@ -313,11 +313,11 @@ const GradientBoostingClassifier_ = sken(:GradientBoostingClassifier)
 end
 MMI.fitted_params(m::GradientBoostingClassifier, (f, _, _)) = (
     n_estimators        = f.n_estimators_,
-    feature_importances = f.feature_importances_,
-    train_score         = f.train_score_,
+    feature_importances = pyconvert(Array, f.feature_importances_),
+    train_score         = pyconvert(Array, f.train_score_),
     init                = f.init_,
     estimators          = f.estimators_,
-    oob_improvement     = m.subsample < 1 ? f.oob_improvement_ : nothing
+    oob_improvement     = m.subsample < 1 ? pyconvert(Array, f.oob_improvement_) : nothing
     )
 meta(GradientBoostingClassifier,
     input   = Table(Continuous),
@@ -364,11 +364,11 @@ end
 MMI.fitted_params(model::RandomForestRegressor, (f, _, _)) = (
     estimator           = f.estimator_,
     estimators          = f.estimators_,
-    feature_importances = f.feature_importances_,
-    n_features          = f.n_features_in_,
-    n_outputs           = f.n_outputs_,
-    oob_score           = model.oob_score ? f.oob_score_ : nothing,
-    oob_prediction      = model.oob_score ? f.oob_prediction_ : nothing
+    feature_importances = pyconvert(Array, f.feature_importances_),
+    n_features          = pyconvert(Int, f.n_features_in_),
+    n_outputs           = pyconvert(Int, f.n_outputs_),
+    oob_score           = model.oob_score ? pyconvert(Float64, f.oob_score_) : nothing,
+    oob_prediction      = model.oob_score ? pyconvert(Array, f.oob_prediction_) : nothing
     )
 meta(RandomForestRegressor,
     input   = Table(Count,Continuous),
@@ -414,12 +414,12 @@ end
 MMI.fitted_params(m::RandomForestClassifier, (f, _, _)) = (
     estimator             = f.estimator_,
     estimators            = f.estimators_,
-    classes               = f.classes_,
-    n_classes             = f.n_classes_,
-    n_features            = f.n_features_in_,
-    n_outputs             = f.n_outputs_,
-    feature_importances   = f.feature_importances_,
-    oob_score             = m.oob_score ? f.oob_score_ : nothing,
+    classes               = pyconvert(Array, f.classes_),
+    n_classes             = pyconvert(Int, f.n_classes_),
+    n_features            = pyconvert(Int, f.n_features_in_),
+    n_outputs             = pyconvert(Int, f.n_outputs_),
+    feature_importances   = pyconvert(Array, f.feature_importances_),
+    oob_score             = m.oob_score ? pyconvert(Float64, f.oob_score_) : nothing,
     oob_decision_function = m.oob_score ? f.oob_decision_function_ : nothing
     )
 meta(RandomForestClassifier,

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -47,7 +47,7 @@ MMI.fitted_params(m::AdaBoostClassifier, (f, _, _)) = (
     estimator_errors  = pyconvert(Array, f.estimator_errors_),
     classes           = pyconvert(Array, f.classes_),
     n_classes         = pyconvert(Int, f.n_classes_),
-    feature_importances  = pyconvert(Array, f.feature_importances_)
+    feature_importances = pyconvert(Array, f.feature_importances_)
     )
 meta(AdaBoostClassifier,
     input   = Table(Continuous),

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -14,6 +14,20 @@ MMI.fitted_params(model::AdaBoostRegressor, (f, _, _)) = (
     feature_importances  = f.feature_importances_
     )
 add_human_name_trait(AdaBoostRegressor, "AdaBoost ensemble regression")
+"""
+$(MMI.doc_header(AdaBoostRegressor))
+
+An AdaBoost regressor is a meta-estimator that begins by fitting 
+a regressor on the original dataset and then fits additional 
+copies of the regressor on the same dataset but where the weights 
+of instances are adjusted according to the error of the current 
+prediction. As such, subsequent regressors focus more on difficult 
+cases.
+
+This class implements the algorithm known as AdaBoost.R2.
+
+"""
+AdaBoostRegressor
 
 # ----------------------------------------------------------------------------
 const AdaBoostClassifier_ = sken(:AdaBoostClassifier)
@@ -37,6 +51,19 @@ meta(AdaBoostClassifier,
     target  = AbstractVector{<:Finite},
     weights = false,
     )
+"""
+$(MMI.doc_header(AdaBoostClassifier))
+
+An AdaBoost  classifier is a meta-estimator that begins by fitting a 
+classifier on the original dataset and then fits additional copies of 
+the classifier on the same dataset but where the weights of incorrectly 
+classified instances are adjusted such that subsequent classifiers 
+focus more on difficult cases.
+
+This class implements the algorithm known as AdaBoost-SAMME.
+
+"""
+AdaBoostClassifier
 
 # ============================================================================
 const BaggingRegressor_ = sken(:BaggingRegressor)
@@ -62,6 +89,20 @@ MMI.fitted_params(model::BaggingRegressor, (f, _, _)) = (
     oob_prediction      = model.oob_score ? f.oob_prediction_ : nothing
     )
 add_human_name_trait(BaggingRegressor, "bagging ensemble regressor")
+"""
+$(MMI.doc_header(BaggingRegressor))
+
+A Bagging regressor is an ensemble meta-estimator that fits base 
+regressors each on random subsets of the original dataset and then 
+aggregate their individual predictions (either by voting or by 
+averaging) to form a final prediction. Such a meta-estimator can 
+typically be used as a way to reduce the variance of a black-box 
+estimator (e.g., a decision tree), by introducing randomization 
+into its construction procedure and then making an ensemble out 
+of it.
+
+"""
+BaggingRegressor
 
 # ----------------------------------------------------------------------------
 const BaggingClassifier_ = sken(:BaggingClassifier)
@@ -94,160 +135,19 @@ meta(BaggingClassifier,
     weights = false,
     human_name   = "bagging ensemble classifier"
     )
+"""
+$(MMI.doc_header(BaggingClassifier))
 
-# ============================================================================
-const GradientBoostingRegressor_ = sken(:GradientBoostingRegressor)
-@sk_reg mutable struct GradientBoostingRegressor <: MMI.Deterministic
-    loss::String                    = "squared_error"::(_ in ("squared_error","absolute_error","huber","quantile"))
-    learning_rate::Float64          = 0.1::(_>0)
-    n_estimators::Int               = 100::(_>0)
-    subsample::Float64              = 1.0::(_>0)
-    criterion::String               = "friedman_mse"::(_ in ("squared_error","friedman_mse"))
-    min_samples_split::Union{Int,Float64} = 2::(_>0)
-    min_samples_leaf::Union{Int,Float64}  = 1::(_>0)
-    min_weight_fraction_leaf::Float64     = 0.0::(_≥0)
-    max_depth::Int                 = 3::(_>0)
-    min_impurity_decrease::Float64 = 0.0::(_≥0)
-    init::Any                      = nothing
-    random_state::Any              = nothing
-    max_features::Union{Int,Float64,String,Nothing} = nothing::(_===nothing || (isa(_,String) && (_ in ("auto","sqrt","log2"))) || (_ isa Number && _ > 0))
-    alpha::Float64                 = 0.9::(_>0)
-    verbose::Int                   = 0
-    max_leaf_nodes::Option{Int}    = nothing::(_===nothing || _>0)
-    warm_start::Bool               = false
-#    presort::Union{Bool,String}    = "auto"::(isa(_, Bool) || _ == "auto")
-    validation_fraction::Float64   = 0.1::(_>0)
-    n_iter_no_change::Option{Int}  = nothing
-    tol::Float64                   = 1e-4::(_>0)
-end
-MMI.fitted_params(m::GradientBoostingRegressor, (f, _, _)) = (
-    feature_importances = f.feature_importances_,
-    train_score         = f.train_score_,
-    init                = f.init_,
-    estimators          = f.estimators_,
-    oob_improvement     = m.subsample < 1 ? f.oob_improvement_ : nothing
-    )
-add_human_name_trait(GradientBoostingRegressor, "gradient boosting ensemble regression")
+A Bagging classifier is an ensemble meta-estimator that fits base 
+classifiers each on random subsets of the original dataset and then 
+aggregate their individual predictions (either by voting or by 
+averaging) to form a final prediction. Such a meta-estimator can 
+typically be used as a way to reduce the variance of a black-box 
+estimator (e.g., a decision tree), by introducing randomization into 
+its construction procedure and then making an ensemble out of it.
 
-# ----------------------------------------------------------------------------
-const GradientBoostingClassifier_ = sken(:GradientBoostingClassifier)
-@sk_clf mutable struct GradientBoostingClassifier <: MMI.Probabilistic
-    loss::String                    = "log_loss"::(_ in ("log_loss","exponential"))
-    learning_rate::Float64          = 0.1::(_>0)
-    n_estimators::Int               = 100::(_>0)
-    subsample::Float64              = 1.0::(_>0)
-    criterion::String               = "friedman_mse"::(_ in ("mse","mae","friedman_mse"))
-    min_samples_split::Union{Int,Float64} = 2::(_>0)
-    min_samples_leaf::Union{Int,Float64}  = 1::(_>0)
-    min_weight_fraction_leaf::Float64     = 0.0::(_≥0)
-    max_depth::Int                 = 3::(_>0)
-    min_impurity_decrease::Float64 = 0.0::(_≥0)
-    init::Any                      = nothing
-    random_state::Any              = nothing
-    max_features::Union{Int,Float64,String,Nothing} = nothing::(_===nothing || (isa(_,String) && (_ in ("auto","sqrt","log2"))) || (_ isa Number && _ > 0))
-    verbose::Int                   = 0
-    max_leaf_nodes::Option{Int}    = nothing::(_===nothing || _>0)
-    warm_start::Bool               = false
-#    presort::Union{Bool,String}    = "auto"::(isa(_, Bool) || _ == "auto")
-    validation_fraction::Float64   = 0.1::(_>0)
-    n_iter_no_change::Option{Int}  = nothing
-    tol::Float64                   = 1e-4::(_>0)
-end
-MMI.fitted_params(m::GradientBoostingClassifier, (f, _, _)) = (
-    n_estimators        = f.n_estimators_,
-    feature_importances = f.feature_importances_,
-    train_score         = f.train_score_,
-    init                = f.init_,
-    estimators          = f.estimators_,
-    oob_improvement     = m.subsample < 1 ? f.oob_improvement_ : nothing
-    )
-meta(GradientBoostingClassifier,
-    input   = Table(Continuous),
-    target  = AbstractVector{<:Finite},
-    weights = false
-    )
-
-# ============================================================================
-const RandomForestRegressor_ = sken(:RandomForestRegressor)
-@sk_reg mutable struct RandomForestRegressor <: MMI.Deterministic
-    n_estimators::Int              = 100::(_ > 0)
-    criterion::String              = "squared_error"::(_ in ("squared_error","absolute_error", "friedman_mse", "poisson"))
-    max_depth::Option{Int}         = nothing::(_ === nothing || _ > 0)
-    min_samples_split::Union{Int,Float64} = 2::(_ > 0)
-    min_samples_leaf::Union{Int,Float64}  = 1::(_ > 0)
-    min_weight_fraction_leaf::Float64     = 0.0::(_ ≥ 0)
-    max_features::Union{Int,Float64,String,Nothing} = 1.0::(_ === nothing || (isa(_, String) && (_ in ("sqrt","log2"))) || (_ isa Number && _ > 0))
-    max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
-    min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
-    bootstrap::Bool                = true
-    oob_score::Bool                = false
-    n_jobs::Option{Int}            = nothing
-    random_state::Any              = nothing
-    verbose::Int                   = 0
-    warm_start::Bool               = false
-    ccp_alpha::Float64             =0.0::(_ ≥ 0)
-    max_samples::Union{Nothing,Float64,Int} =
-        nothing::(_ === nothing || (_ ≥ 0 && (_ isa Integer || _ ≤ 1)))
-end
-MMI.fitted_params(model::RandomForestRegressor, (f, _, _)) = (
-    estimator           = f.estimator_,
-    estimators          = f.estimators_,
-    feature_importances = f.feature_importances_,
-    n_features          = f.n_features_in_,
-    n_outputs           = f.n_outputs_,
-    oob_score           = model.oob_score ? f.oob_score_ : nothing,
-    oob_prediction      = model.oob_score ? f.oob_prediction_ : nothing
-    )
-meta(RandomForestRegressor,
-    input   = Table(Count,Continuous),
-    target  = AbstractVector{Continuous},
-    weights = false
-    )
-
-# ----------------------------------------------------------------------------
-const RandomForestClassifier_ = sken(:RandomForestClassifier)
-@sk_clf mutable struct RandomForestClassifier <: MMI.Probabilistic
-    n_estimators::Int              = 100::(_ > 0)
-    criterion::String              = "gini"::(_ in ("gini","entropy", "log_loss"))
-    max_depth::Option{Int}         = nothing::(_ === nothing || _ > 0)
-    min_samples_split::Union{Int,Float64} = 2::(_ > 0)
-    min_samples_leaf::Union{Int,Float64}  = 1::(_ > 0)
-    min_weight_fraction_leaf::Float64     = 0.0::(_ ≥ 0)
-    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("sqrt","log2"))) || (_ isa Number && _ > 0))
-    max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
-    min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
-    bootstrap::Bool                = true
-    oob_score::Bool                = false
-    n_jobs::Option{Int}            = nothing
-    random_state::Any              = nothing
-    verbose::Int                   = 0
-    warm_start::Bool               = false
-    class_weight::Any              = nothing
-    ccp_alpha::Float64             =0.0::(_ ≥ 0)
-    max_samples::Union{Nothing,Float64,Int} =
-        nothing::(_ === nothing || (_ ≥ 0 && (_ isa Integer || _ ≤ 1)))
-end
-MMI.fitted_params(m::RandomForestClassifier, (f, _, _)) = (
-    estimator             = f.estimator_,
-    estimators            = f.estimators_,
-    classes               = f.classes_,
-    n_classes             = f.n_classes_,
-    n_features            = f.n_features_in_,
-    n_outputs             = f.n_outputs_,
-    feature_importances   = f.feature_importances_,
-    oob_score             = m.oob_score ? f.oob_score_ : nothing,
-    oob_decision_function = m.oob_score ? f.oob_decision_function_ : nothing
-    )
-meta(RandomForestClassifier,
-    input   = Table(Count,Continuous),
-    target  = AbstractVector{<:Finite},
-    weights = false
-    )
-
-const ENSEMBLE_REG = Union{Type{<:AdaBoostRegressor}, Type{<:BaggingRegressor}, Type{<:GradientBoostingRegressor}}
-
-MMI.input_scitype(::ENSEMBLE_REG)  = Table(Continuous)
-MMI.target_scitype(::ENSEMBLE_REG) = AbstractVector{Continuous}
+"""
+BaggingClassifier
 
 # ============================================================================
 const ExtraTreesRegressor_ = sken(:ExtraTreesRegressor)
@@ -339,3 +239,309 @@ predictive accuracy and control over-fitting.
 
 """
 ExtraTreesClassifier
+
+# ============================================================================
+const GradientBoostingRegressor_ = sken(:GradientBoostingRegressor)
+@sk_reg mutable struct GradientBoostingRegressor <: MMI.Deterministic
+    loss::String                    = "squared_error"::(_ in ("squared_error","absolute_error","huber","quantile"))
+    learning_rate::Float64          = 0.1::(_>0)
+    n_estimators::Int               = 100::(_>0)
+    subsample::Float64              = 1.0::(_>0)
+    criterion::String               = "friedman_mse"::(_ in ("squared_error","friedman_mse"))
+    min_samples_split::Union{Int,Float64} = 2::(_>0)
+    min_samples_leaf::Union{Int,Float64}  = 1::(_>0)
+    min_weight_fraction_leaf::Float64     = 0.0::(_≥0)
+    max_depth::Int                 = 3::(_>0)
+    min_impurity_decrease::Float64 = 0.0::(_≥0)
+    init::Any                      = nothing
+    random_state::Any              = nothing
+    max_features::Union{Int,Float64,String,Nothing} = nothing::(_===nothing || (isa(_,String) && (_ in ("auto","sqrt","log2"))) || (_ isa Number && _ > 0))
+    alpha::Float64                 = 0.9::(_>0)
+    verbose::Int                   = 0
+    max_leaf_nodes::Option{Int}    = nothing::(_===nothing || _>0)
+    warm_start::Bool               = false
+#    presort::Union{Bool,String}    = "auto"::(isa(_, Bool) || _ == "auto")
+    validation_fraction::Float64   = 0.1::(_>0)
+    n_iter_no_change::Option{Int}  = nothing
+    tol::Float64                   = 1e-4::(_>0)
+end
+MMI.fitted_params(m::GradientBoostingRegressor, (f, _, _)) = (
+    feature_importances = f.feature_importances_,
+    train_score         = f.train_score_,
+    init                = f.init_,
+    estimators          = f.estimators_,
+    oob_improvement     = m.subsample < 1 ? f.oob_improvement_ : nothing
+    )
+add_human_name_trait(GradientBoostingRegressor, "gradient boosting ensemble regression")
+"""
+$(MMI.doc_header(GradientBoostingRegressor))
+
+This estimator builds an additive model in a forward stage-wise fashion; 
+it allows for the optimization of arbitrary differentiable loss functions. 
+In each stage a regression tree is fit on the negative gradient of the 
+given loss function.
+
+[`HistGradientBoostingRegressor`](@ref) is a much faster variant of this 
+algorithm for intermediate datasets (`n_samples >= 10_000`).
+
+"""
+GradientBoostingRegressor
+
+# ----------------------------------------------------------------------------
+const GradientBoostingClassifier_ = sken(:GradientBoostingClassifier)
+@sk_clf mutable struct GradientBoostingClassifier <: MMI.Probabilistic
+    loss::String                    = "log_loss"::(_ in ("log_loss","exponential"))
+    learning_rate::Float64          = 0.1::(_>0)
+    n_estimators::Int               = 100::(_>0)
+    subsample::Float64              = 1.0::(_>0)
+    criterion::String               = "friedman_mse"::(_ in ("mse","mae","friedman_mse"))
+    min_samples_split::Union{Int,Float64} = 2::(_>0)
+    min_samples_leaf::Union{Int,Float64}  = 1::(_>0)
+    min_weight_fraction_leaf::Float64     = 0.0::(_≥0)
+    max_depth::Int                 = 3::(_>0)
+    min_impurity_decrease::Float64 = 0.0::(_≥0)
+    init::Any                      = nothing
+    random_state::Any              = nothing
+    max_features::Union{Int,Float64,String,Nothing} = nothing::(_===nothing || (isa(_,String) && (_ in ("auto","sqrt","log2"))) || (_ isa Number && _ > 0))
+    verbose::Int                   = 0
+    max_leaf_nodes::Option{Int}    = nothing::(_===nothing || _>0)
+    warm_start::Bool               = false
+#    presort::Union{Bool,String}    = "auto"::(isa(_, Bool) || _ == "auto")
+    validation_fraction::Float64   = 0.1::(_>0)
+    n_iter_no_change::Option{Int}  = nothing
+    tol::Float64                   = 1e-4::(_>0)
+end
+MMI.fitted_params(m::GradientBoostingClassifier, (f, _, _)) = (
+    n_estimators        = f.n_estimators_,
+    feature_importances = f.feature_importances_,
+    train_score         = f.train_score_,
+    init                = f.init_,
+    estimators          = f.estimators_,
+    oob_improvement     = m.subsample < 1 ? f.oob_improvement_ : nothing
+    )
+meta(GradientBoostingClassifier,
+    input   = Table(Continuous),
+    target  = AbstractVector{<:Finite},
+    weights = false
+    )
+"""
+$(MMI.doc_header(GradientBoostingClassifier))
+
+This algorithm builds an additive model in a forward stage-wise fashion; 
+it allows for the optimization of arbitrary differentiable loss functions. 
+In each stage `n_classes_` regression trees are fit on the negative gradient 
+of the loss function, e.g. binary or multiclass log loss. Binary 
+classification is a special case where only a single regression tree is induced.
+
+[`HistGradientBoostingClassifier`](@ref) is a much faster variant of this 
+algorithm for intermediate datasets (`n_samples >= 10_000`).
+
+"""
+GradientBoostingClassifier
+
+# ============================================================================
+const RandomForestRegressor_ = sken(:RandomForestRegressor)
+@sk_reg mutable struct RandomForestRegressor <: MMI.Deterministic
+    n_estimators::Int              = 100::(_ > 0)
+    criterion::String              = "squared_error"::(_ in ("squared_error","absolute_error", "friedman_mse", "poisson"))
+    max_depth::Option{Int}         = nothing::(_ === nothing || _ > 0)
+    min_samples_split::Union{Int,Float64} = 2::(_ > 0)
+    min_samples_leaf::Union{Int,Float64}  = 1::(_ > 0)
+    min_weight_fraction_leaf::Float64     = 0.0::(_ ≥ 0)
+    max_features::Union{Int,Float64,String,Nothing} = 1.0::(_ === nothing || (isa(_, String) && (_ in ("sqrt","log2"))) || (_ isa Number && _ > 0))
+    max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
+    min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
+    bootstrap::Bool                = true
+    oob_score::Bool                = false
+    n_jobs::Option{Int}            = nothing
+    random_state::Any              = nothing
+    verbose::Int                   = 0
+    warm_start::Bool               = false
+    ccp_alpha::Float64             =0.0::(_ ≥ 0)
+    max_samples::Union{Nothing,Float64,Int} =
+        nothing::(_ === nothing || (_ ≥ 0 && (_ isa Integer || _ ≤ 1)))
+end
+MMI.fitted_params(model::RandomForestRegressor, (f, _, _)) = (
+    estimator           = f.estimator_,
+    estimators          = f.estimators_,
+    feature_importances = f.feature_importances_,
+    n_features          = f.n_features_in_,
+    n_outputs           = f.n_outputs_,
+    oob_score           = model.oob_score ? f.oob_score_ : nothing,
+    oob_prediction      = model.oob_score ? f.oob_prediction_ : nothing
+    )
+meta(RandomForestRegressor,
+    input   = Table(Count,Continuous),
+    target  = AbstractVector{Continuous},
+    weights = false
+    )
+"""
+$(MMI.doc_header(RandomForestRegressor))
+
+A random forest is a meta estimator that fits a number of 
+classifying decision trees on various sub-samples of the 
+dataset and uses averaging to improve the predictive accuracy 
+and control over-fitting. The sub-sample size is controlled 
+with the `max_samples` parameter if `bootstrap=True` (default), 
+otherwise the whole dataset is used to build each tree.
+
+"""
+RandomForestRegressor
+
+# ----------------------------------------------------------------------------
+const RandomForestClassifier_ = sken(:RandomForestClassifier)
+@sk_clf mutable struct RandomForestClassifier <: MMI.Probabilistic
+    n_estimators::Int              = 100::(_ > 0)
+    criterion::String              = "gini"::(_ in ("gini","entropy", "log_loss"))
+    max_depth::Option{Int}         = nothing::(_ === nothing || _ > 0)
+    min_samples_split::Union{Int,Float64} = 2::(_ > 0)
+    min_samples_leaf::Union{Int,Float64}  = 1::(_ > 0)
+    min_weight_fraction_leaf::Float64     = 0.0::(_ ≥ 0)
+    max_features::Union{Int,Float64,String,Nothing} = "sqrt"::(_ === nothing || (isa(_, String) && (_ in ("sqrt","log2"))) || (_ isa Number && _ > 0))
+    max_leaf_nodes::Option{Int}    = nothing::(_ === nothing || _ > 0)
+    min_impurity_decrease::Float64 = 0.0::(_ ≥ 0)
+    bootstrap::Bool                = true
+    oob_score::Bool                = false
+    n_jobs::Option{Int}            = nothing
+    random_state::Any              = nothing
+    verbose::Int                   = 0
+    warm_start::Bool               = false
+    class_weight::Any              = nothing
+    ccp_alpha::Float64             =0.0::(_ ≥ 0)
+    max_samples::Union{Nothing,Float64,Int} =
+        nothing::(_ === nothing || (_ ≥ 0 && (_ isa Integer || _ ≤ 1)))
+end
+MMI.fitted_params(m::RandomForestClassifier, (f, _, _)) = (
+    estimator             = f.estimator_,
+    estimators            = f.estimators_,
+    classes               = f.classes_,
+    n_classes             = f.n_classes_,
+    n_features            = f.n_features_in_,
+    n_outputs             = f.n_outputs_,
+    feature_importances   = f.feature_importances_,
+    oob_score             = m.oob_score ? f.oob_score_ : nothing,
+    oob_decision_function = m.oob_score ? f.oob_decision_function_ : nothing
+    )
+meta(RandomForestClassifier,
+    input   = Table(Count,Continuous),
+    target  = AbstractVector{<:Finite},
+    weights = false
+    )
+"""
+$(MMI.doc_header(RandomForestClassifier))
+
+A random forest is a meta estimator that fits a number of 
+classifying decision trees on various sub-samples of the 
+dataset and uses averaging to improve the predictive accuracy 
+and control over-fitting. The sub-sample size is controlled 
+with the `max_samples` parameter if `bootstrap=True` (default), 
+otherwise the whole dataset is used to build each tree.
+
+"""
+RandomForestClassifier
+
+# ============================================================================
+const HistGradientBoostingRegressor_ = sken(:HistGradientBoostingRegressor)
+@sk_reg mutable struct HistGradientBoostingRegressor <: MMI.Deterministic
+    loss::String                    = "squared_error"::(_ in ("squared_error","absolute_error","gamma","poisson", "quantile"))
+    quantile::Option{Float64}       = nothing::(_===nothing || 0<_>1)
+    learning_rate::Float64          = 0.1::(_>0)
+    max_iter::Int                   = 100::(_>0)
+    max_leaf_nodes::Option{Int}     = 31::(_===nothing || _>0)
+    max_depth::Option{Int}          = nothing::(_===nothing || _>0)
+    min_samples_leaf::Union{Int,Float64} = 20::(_>0)
+    l2_regularization::Float64      = 0.0
+    max_bins::Int                   = 255
+    categorical_features::Option{Vector} = nothing
+    monotonic_cst::Option{Union{Vector, Dict}} = nothing
+    # interaction_cst
+    warm_start::Bool                = false
+    early_stopping::Union{String, Bool} = "auto"::(_ in ("auto", true, false))
+    scoring::String                 = "loss"
+    validation_fraction::Option{Union{Int, Float64}} = 0.1::(_===nothing || _≥0)
+    n_iter_no_change::Option{Int}  = 10::(_===nothing || _>0)
+    tol::Float64                   = 1e-7::(_>0)
+    random_state::Any              = nothing
+end
+MMI.fitted_params(m::HistGradientBoostingRegressor, (f, _, _)) = (
+    do_early_stopping   = pyconvert(Bool, f.do_early_stopping_),
+    n_iter              = pyconvert(Int, f.n_iter_),
+    n_trees_per_iteration = pyconvert(Int, f.n_trees_per_iteration_),
+    train_score         = pyconvert(Array, f.train_score_),
+    validation_score    = pyconvert(Array, f.validation_score_)
+    )
+add_human_name_trait(HistGradientBoostingRegressor, "gradient boosting ensemble regression")
+"""
+$(MMI.doc_header(HistGradientBoostingRegressor))
+
+This estimator builds an additive model in a forward stage-wise fashion; 
+it allows for the optimization of arbitrary differentiable loss functions. 
+In each stage a regression tree is fit on the negative gradient of the 
+given loss function.
+
+[`HistGradientBoostingRegressor`](@ref) is a much faster variant of this 
+algorithm for intermediate datasets (`n_samples >= 10_000`).
+
+"""
+HistGradientBoostingRegressor
+
+# ----------------------------------------------------------------------------
+const HistGradientBoostingClassifier_ = sken(:HistGradientBoostingClassifier)
+@sk_clf mutable struct HistGradientBoostingClassifier <: MMI.Probabilistic
+    loss::String                    = "log_loss"::(_ in ("log_loss",))
+    learning_rate::Float64          = 0.1::(_>0)
+    max_iter::Int                   = 100::(_>0)
+    max_leaf_nodes::Option{Int}     = 31::(_===nothing || _>0)
+    max_depth::Option{Int}          = nothing::(_===nothing || _>0)
+    min_samples_leaf::Union{Int,Float64} = 20::(_>0)
+    l2_regularization::Float64      = 0.0
+    max_bins::Int                   = 255
+    categorical_features::Option{Vector} = nothing
+    monotonic_cst::Option{Union{Vector, Dict}} = nothing
+    # interaction_cst
+    warm_start::Bool                = false
+    early_stopping::Union{String, Bool} = "auto"::(_ in ("auto",) || _ isa Bool)
+    scoring::String                 = "loss"
+    validation_fraction::Option{Union{Int, Float64}} = 0.1::(_===nothing || _≥0)
+    n_iter_no_change::Option{Int}  = 10::(_===nothing || _>0)
+    tol::Float64                   = 1e-7::(_>0)
+    random_state::Any              = nothing
+    class_weight::Any              = nothing
+end
+MMI.fitted_params(m::HistGradientBoostingClassifier, (f, _, _)) = (
+    classes             = pyconvert(Array, f.classes_),
+    do_early_stopping   = pyconvert(Bool, f.do_early_stopping_),
+    n_iter              = pyconvert(Int, f.n_iter_),
+    n_trees_per_iteration = pyconvert(Int, f.n_trees_per_iteration_),
+    train_score         = pyconvert(Array, f.train_score_),
+    validation_score    = pyconvert(Array, f.validation_score_)
+    )
+meta(HistGradientBoostingClassifier,
+    input   = Table(Continuous),
+    target  = AbstractVector{<:Finite},
+    weights = false
+    )
+"""
+$(MMI.doc_header(HistGradientBoostingClassifier))
+
+This algorithm builds an additive model in a forward stage-wise fashion; 
+it allows for the optimization of arbitrary differentiable loss functions. 
+In each stage `n_classes_` regression trees are fit on the negative gradient 
+of the loss function, e.g. binary or multiclass log loss. Binary 
+classification is a special case where only a single regression tree is induced.
+
+[`HistGradientBoostingClassifier`](@ref) is a much faster variant of this 
+algorithm for intermediate datasets (`n_samples >= 10_000`).
+
+"""
+HistGradientBoostingClassifier
+
+# ----------------------------------------------------------------------------
+const ENSEMBLE_REG = Union{Type{<:AdaBoostRegressor}, 
+                           Type{<:BaggingRegressor}, 
+                           Type{<:ExtraTreesRegressor},
+                           Type{<:GradientBoostingRegressor},
+                           Type{<:HistGradientBoostingRegressor}}
+
+MMI.input_scitype(::ENSEMBLE_REG)  = Table(Continuous)
+MMI.target_scitype(::ENSEMBLE_REG) = AbstractVector{Continuous}

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -6,6 +6,7 @@ const AdaBoostRegressor_ = sken(:AdaBoostRegressor)
     loss::String           = "linear"::(_ in ("linear","square","exponential"))
     random_state::Any      = nothing
 end
+@sk_feature_importances AdaBoostRegressor
 MMI.fitted_params(model::AdaBoostRegressor, (f, _, _)) = (
     estimator            = f.estimator_,
     estimators           = f.estimators_,
@@ -38,13 +39,15 @@ const AdaBoostClassifier_ = sken(:AdaBoostClassifier)
     algorithm::String      = "SAMME.R"::(_ in ("SAMME", "SAMME.R"))
     random_state::Any      = nothing
 end
+@sk_feature_importances AdaBoostClassifier
 MMI.fitted_params(m::AdaBoostClassifier, (f, _, _)) = (
     estimator         = f.estimator_,
     estimators        = f.estimators_,
     estimator_weights = pyconvert(Array, f.estimator_weights_),
     estimator_errors  = pyconvert(Array, f.estimator_errors_),
     classes           = pyconvert(Array, f.classes_),
-    n_classes         = pyconvert(Int, f.n_classes_)
+    n_classes         = pyconvert(Int, f.n_classes_),
+    feature_importances  = pyconvert(Array, f.feature_importances_)
     )
 meta(AdaBoostClassifier,
     input   = Table(Continuous),
@@ -168,6 +171,7 @@ const ExtraTreesRegressor_ = sken(:ExtraTreesRegressor)
     verbose::Int                   = 0
     warm_start::Bool               = false
 end
+@sk_feature_importances ExtraTreesRegressor
 MMI.fitted_params(m::ExtraTreesRegressor, (f, _, _)) = (
     estimator           = f.estimator_,
     estimators          = f.estimators_,
@@ -213,6 +217,7 @@ const ExtraTreesClassifier_ = sken(:ExtraTreesClassifier)
     warm_start::Bool               = false
     class_weight::Any              = nothing
 end
+@sk_feature_importances ExtraTreesClassifier
 MMI.fitted_params(m::ExtraTreesClassifier, (f, _, _)) = (
     estimator             = f.estimator_,
     estimators            = f.estimators_,
@@ -265,6 +270,7 @@ const GradientBoostingRegressor_ = sken(:GradientBoostingRegressor)
     n_iter_no_change::Option{Int}  = nothing
     tol::Float64                   = 1e-4::(_>0)
 end
+@sk_feature_importances GradientBoostingRegressor
 MMI.fitted_params(m::GradientBoostingRegressor, (f, _, _)) = (
     feature_importances = pyconvert(Array, f.feature_importances_),
     train_score         = pyconvert(Array, f.train_score_),
@@ -311,6 +317,7 @@ const GradientBoostingClassifier_ = sken(:GradientBoostingClassifier)
     n_iter_no_change::Option{Int}  = nothing
     tol::Float64                   = 1e-4::(_>0)
 end
+@sk_feature_importances GradientBoostingClassifier
 MMI.fitted_params(m::GradientBoostingClassifier, (f, _, _)) = (
     n_estimators        = f.n_estimators_,
     feature_importances = pyconvert(Array, f.feature_importances_),
@@ -361,6 +368,7 @@ const RandomForestRegressor_ = sken(:RandomForestRegressor)
     max_samples::Union{Nothing,Float64,Int} =
         nothing::(_ === nothing || (_ ≥ 0 && (_ isa Integer || _ ≤ 1)))
 end
+@sk_feature_importances RandomForestRegressor
 MMI.fitted_params(model::RandomForestRegressor, (f, _, _)) = (
     estimator           = f.estimator_,
     estimators          = f.estimators_,
@@ -411,6 +419,7 @@ const RandomForestClassifier_ = sken(:RandomForestClassifier)
     max_samples::Union{Nothing,Float64,Int} =
         nothing::(_ === nothing || (_ ≥ 0 && (_ isa Integer || _ ≤ 1)))
 end
+@sk_feature_importances RandomForestClassifier
 MMI.fitted_params(m::RandomForestClassifier, (f, _, _)) = (
     estimator             = f.estimator_,
     estimators            = f.estimators_,

--- a/src/models/gaussian-process.jl
+++ b/src/models/gaussian-process.jl
@@ -38,9 +38,9 @@ const GaussianProcessClassifier_ = skgp(:GaussianProcessClassifier)
 end
 MMI.fitted_params(m::GaussianProcessClassifier, (f, _, _)) = (
     kernel    = f.kernel_,
-    log_marginal_likelihood_value = f.log_marginal_likelihood_value_,
-    classes   = f.classes_,
-    n_classes = f.n_classes_
+    log_marginal_likelihood_value = pyconvert(Float64, f.log_marginal_likelihood_value_),
+    classes   = pyconvert(Array, f.classes_),
+    n_classes = pyconvert(Int, f.n_classes_)
     )
 meta(GaussianProcessClassifier,
     input   = Table(Continuous),

--- a/src/models/linear-classifiers.jl
+++ b/src/models/linear-classifiers.jl
@@ -17,8 +17,8 @@ const LogisticClassifier_ = sklm(:LogisticRegression)
     l1_ratio::Option{Float64}  = nothing::(_ === nothing || 0 ≤ _ ≤ 1)
 end
 MMI.fitted_params(m::LogisticClassifier, (f, _, _)) = (
-    classes   = f.classes_,
-    coef      = f.coef_,
+    classes   = pyconvert(Array, f.classes_),
+    coef      = pyconvert(Array, f.coef_),
     intercept = ifelse(m.fit_intercept, f.intercept_, nothing)
     )
 meta(LogisticClassifier,
@@ -50,15 +50,15 @@ const LogisticCVClassifier_ = sklm(:LogisticRegressionCV)
     l1_ratios::Option{AbstractVector{Float64}}=nothing::(_ === nothing || all(0 .≤ _ .≤ 1))
 end
 MMI.fitted_params(m::LogisticCVClassifier, (f, _, _)) = (
-    classes     = f.classes_,
-    coef        = f.coef_,
-    intercept   = m.fit_intercept ? f.intercept_ : nothing,
-    Cs          = f.Cs_,
+    classes     = pyconvert(Array, f.classes_),
+    coef        = pyconvert(Array, f.coef_),
+    intercept   = m.fit_intercept ? pyconvert(Array, f.intercept_) : nothing,
+    Cs          = pyconvert(Array, f.Cs_),
     l1_ratios   = ifelse(m.penalty == "elasticnet", f.l1_ratios_, nothing),
-    coefs_paths = f.coefs_paths_,
+    coefs_paths = pyconvert(Array, f.coefs_paths_),
     scores      = f.scores_,
-    C           = f.C_,
-    l1_ratio    = f.l1_ratio_
+    C           = pyconvert(Array, f.C_),
+    l1_ratio    = pyconvert(Array, f.l1_ratio_)
     )
 meta(LogisticCVClassifier,
     input   = Table(Continuous),
@@ -87,7 +87,7 @@ const PassiveAggressiveClassifier_ = sklm(:PassiveAggressiveClassifier)
     average::Bool         = false
 end
 MMI.fitted_params(m::PassiveAggressiveClassifier, (f, _, _)) = (
-    coef      = f.coef_,
+    coef      = pyconvert(Array, f.coef_),
     intercept = ifelse(m.fit_intercept, f.intercept_, nothing)
     )
 meta(PassiveAggressiveClassifier,
@@ -117,7 +117,7 @@ const PerceptronClassifier_ = sklm(:Perceptron)
     warm_start::Bool        = false
 end
 MMI.fitted_params(m::PerceptronClassifier, (f, _, _)) = (
-    coef      = f.coef_,
+    coef      = pyconvert(Array, f.coef_),
     intercept = ifelse(m.fit_intercept, f.intercept_, nothing)
     )
 meta(PerceptronClassifier,
@@ -139,7 +139,7 @@ const RidgeClassifier_ = sklm(:RidgeClassifier)
     random_state::Any     = nothing
 end
 MMI.fitted_params(m::RidgeClassifier, (f, _, _)) = (
-    coef      = f.coef_,
+    coef      = pyconvert(Array, f.coef_),
     intercept = ifelse(m.fit_intercept, f.intercept_, nothing)
     )
 meta(RidgeClassifier,
@@ -160,7 +160,7 @@ const RidgeCVClassifier_ = sklm(:RidgeClassifierCV)
     store_cv_values::Bool = false
 end
 MMI.fitted_params(m::RidgeCVClassifier, (f, _, _)) = (
-    coef      = f.coef_,
+    coef      = pyconvert(Array, f.coef_),
     intercept = ifelse(m.fit_intercept, f.intercept_, nothing)
     )
 meta(RidgeCVClassifier,
@@ -220,12 +220,12 @@ const ProbabilisticSGDClassifier_ = sklm(:SGDClassifier)
     average::Bool         = false
 end
 MMI.fitted_params(m::SGDClassifier, (f,_,_)) = (
-    coef      = f.coef_,
+    coef      = pyconvert(Array, f.coef_),
     intercept = ifelse(m.fit_intercept, f.intercept_, nothing)
     )
 # duplication to avoid ambiguity that julia doesn't like
 MMI.fitted_params(m::ProbabilisticSGDClassifier, (f,_,_)) = (
-    coef      = f.coef_,
+    coef      = pyconvert(Array, f.coef_),
     intercept = ifelse(m.fit_intercept, f.intercept_, nothing)
     )
 meta.((SGDClassifier, ProbabilisticSGDClassifier),

--- a/src/models/linear-classifiers.jl
+++ b/src/models/linear-classifiers.jl
@@ -27,6 +27,7 @@ meta(LogisticClassifier,
     weights = false,
     human_name  = "logistic regression classifier"
     )
+@sk_feature_importances LogisticClassifier
 
 # ============================================================================
 const LogisticCVClassifier_ = sklm(:LogisticRegressionCV)
@@ -66,6 +67,7 @@ meta(LogisticCVClassifier,
     weights = false,
     human_name   = "logistic regression classifier $CV"
     )
+@sk_feature_importances LogisticCVClassifier
 
 # ============================================================================
 const PassiveAggressiveClassifier_ = sklm(:PassiveAggressiveClassifier)
@@ -96,6 +98,7 @@ meta(PassiveAggressiveClassifier,
     weights = false,
     human_name   = "passive aggressive classifier"
     )
+@sk_feature_importances PassiveAggressiveClassifier
 
 # ============================================================================
 const PerceptronClassifier_ = sklm(:Perceptron)
@@ -125,6 +128,7 @@ meta(PerceptronClassifier,
     target  = AbstractVector{<:Finite},
     weights = false,
     )
+@sk_feature_importances PerceptronClassifier
 
 # ============================================================================
 const RidgeClassifier_ = sklm(:RidgeClassifier)
@@ -148,6 +152,7 @@ meta(RidgeClassifier,
     weights = false,
     human_name   = "ridge regression classifier"
     )
+@sk_feature_importances RidgeClassifier
 
 # ============================================================================
 const RidgeCVClassifier_ = sklm(:RidgeClassifierCV)
@@ -169,6 +174,7 @@ meta(RidgeCVClassifier,
     weights = false,
     human_name   = "ridge regression classifier $CV"
     )
+@sk_feature_importances RidgeCVClassifier
 
 # ============================================================================
 const SGDClassifier_ = sklm(:SGDClassifier)
@@ -233,3 +239,4 @@ meta.((SGDClassifier, ProbabilisticSGDClassifier),
     target  = AbstractVector{<:Finite},
     weights = false
     )
+@sk_feature_importances SGDClassifier

--- a/src/models/linear-classifiers.jl
+++ b/src/models/linear-classifiers.jl
@@ -27,7 +27,6 @@ meta(LogisticClassifier,
     weights = false,
     human_name  = "logistic regression classifier"
     )
-@sk_feature_importances LogisticClassifier
 
 # ============================================================================
 const LogisticCVClassifier_ = sklm(:LogisticRegressionCV)
@@ -67,7 +66,6 @@ meta(LogisticCVClassifier,
     weights = false,
     human_name   = "logistic regression classifier $CV"
     )
-@sk_feature_importances LogisticCVClassifier
 
 # ============================================================================
 const PassiveAggressiveClassifier_ = sklm(:PassiveAggressiveClassifier)
@@ -98,7 +96,6 @@ meta(PassiveAggressiveClassifier,
     weights = false,
     human_name   = "passive aggressive classifier"
     )
-@sk_feature_importances PassiveAggressiveClassifier
 
 # ============================================================================
 const PerceptronClassifier_ = sklm(:Perceptron)
@@ -128,7 +125,6 @@ meta(PerceptronClassifier,
     target  = AbstractVector{<:Finite},
     weights = false,
     )
-@sk_feature_importances PerceptronClassifier
 
 # ============================================================================
 const RidgeClassifier_ = sklm(:RidgeClassifier)
@@ -152,7 +148,6 @@ meta(RidgeClassifier,
     weights = false,
     human_name   = "ridge regression classifier"
     )
-@sk_feature_importances RidgeClassifier
 
 # ============================================================================
 const RidgeCVClassifier_ = sklm(:RidgeClassifierCV)
@@ -174,7 +169,6 @@ meta(RidgeCVClassifier,
     weights = false,
     human_name   = "ridge regression classifier $CV"
     )
-@sk_feature_importances RidgeCVClassifier
 
 # ============================================================================
 const SGDClassifier_ = sklm(:SGDClassifier)
@@ -239,4 +233,3 @@ meta.((SGDClassifier, ProbabilisticSGDClassifier),
     target  = AbstractVector{<:Finite},
     weights = false
     )
-@sk_feature_importances SGDClassifier

--- a/src/models/linear-regressors-multi.jl
+++ b/src/models/linear-regressors-multi.jl
@@ -9,10 +9,11 @@ const MultiTaskLassoRegressor_ = sklm(:MultiTaskLasso)
     selection::String   = "cyclic"::(_ in ("cyclic","random"))
 end
 MMI.fitted_params(model::MultiTaskLassoRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
 add_human_name_trait(MultiTaskLassoRegressor, "multi-target lasso regressor")
+@sk_feature_importances MultiTaskLassoRegressor
 
 # ==============================================================================
 const MultiTaskLassoCVRegressor_ = sklm(:MultiTaskLassoCV)
@@ -31,13 +32,14 @@ const MultiTaskLassoCVRegressor_ = sklm(:MultiTaskLassoCV)
     selection::String   = "cyclic"::(_ in ("cyclic","random"))
 end
 MMI.fitted_params(model::MultiTaskLassoCVRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
     mse_path  = fitresult.mse_path_,
     alphas    = fitresult.alphas_
     )
 add_human_name_trait(MultiTaskLassoCVRegressor, "multi-target lasso regressor $CV")
+@sk_feature_importances MultiTaskLassoCVRegressor
 
 # ==============================================================================
 const MultiTaskElasticNetRegressor_ = sklm(:MultiTaskElasticNet)
@@ -53,10 +55,11 @@ const MultiTaskElasticNetRegressor_ = sklm(:MultiTaskElasticNet)
     selection::String   = "cyclic"::(_ in ("cyclic","random"))
 end
 MMI.fitted_params(model::MultiTaskElasticNetRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
 add_human_name_trait(MultiTaskElasticNetRegressor, "multi-target elastic net regressor")
+@sk_feature_importances MultiTaskElasticNetRegressor
 
 # ==============================================================================
 const MultiTaskElasticNetCVRegressor_ = sklm(:MultiTaskElasticNetCV)
@@ -76,7 +79,7 @@ const MultiTaskElasticNetCVRegressor_ = sklm(:MultiTaskElasticNetCV)
     selection::String   = "cyclic"::(_ in ("cyclic","random"))
 end
 MMI.fitted_params(model::MultiTaskElasticNetCVRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
     mse_path  = fitresult.mse_path_,
@@ -84,7 +87,7 @@ MMI.fitted_params(model::MultiTaskElasticNetCVRegressor, (fitresult, _, _)) = (
     )
 add_human_name_trait(MultiTaskElasticNetCVRegressor, "multi-target elastic "*
                      "net regressor $CV")
-
+@sk_feature_importances MultiTaskElasticNetCVRegressor
 
 const SKL_REGS_MULTI = Union{
        Type{<:MultiTaskLassoRegressor},

--- a/src/models/linear-regressors.jl
+++ b/src/models/linear-regressors.jl
@@ -14,7 +14,7 @@ const ARDRegressor_ = sklm(:ARDRegression)
     verbose::Bool             = false
 end
 MMI.fitted_params(model::ARDRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
     lambda    = fitresult.lambda_,
@@ -22,6 +22,7 @@ MMI.fitted_params(model::ARDRegressor, (fitresult, _, _)) = (
     scores    = fitresult.scores_
     )
 add_human_name_trait(ARDRegressor, "Bayesian ARD regressor")
+@sk_feature_importances ARDRegressor
 
 # =============================================================================
 const BayesianRidgeRegressor_ = sklm(:BayesianRidge)
@@ -39,7 +40,7 @@ const BayesianRidgeRegressor_ = sklm(:BayesianRidge)
     verbose::Bool       = false
 end
 MMI.fitted_params(model::BayesianRidgeRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
     lambda    = fitresult.lambda_,
@@ -47,6 +48,7 @@ MMI.fitted_params(model::BayesianRidgeRegressor, (fitresult, _, _)) = (
     scores    = fitresult.scores_
     )
 add_human_name_trait(BayesianRidgeRegressor, "Bayesian ridge regressor")
+@sk_feature_importances BayesianRidgeRegressor
 
 # =============================================================================
 const ElasticNetRegressor_ = sklm(:ElasticNet)
@@ -64,9 +66,10 @@ const ElasticNetRegressor_ = sklm(:ElasticNet)
     selection::String   = "cyclic"::(_ in ("cyclic","random"))
 end
 MMI.fitted_params(model::ElasticNetRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     )
+@sk_feature_importances ElasticNetRegressor
 
 # =============================================================================
 const ElasticNetCVRegressor_ = sklm(:ElasticNetCV)
@@ -88,13 +91,14 @@ const ElasticNetCVRegressor_ = sklm(:ElasticNetCV)
     selection::String   = "cyclic"::(_ in ("cyclic","random"))
 end
 MMI.fitted_params(model::ElasticNetCVRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     l1_ratio  = fitresult.l1_ratio_,
     mse_path  = fitresult.mse_path_,
     alphas    = fitresult.alphas_
     )
 add_human_name_trait(ElasticNetCVRegressor, "elastic net regression $CV")
+@sk_feature_importances ElasticNetCVRegressor
 
 # =============================================================================
 const HuberRegressor_ = sklm(:HuberRegressor)
@@ -107,12 +111,13 @@ const HuberRegressor_ = sklm(:HuberRegressor)
     tol::Float64        = 1e-5::(_ > 0)
 end
 MMI.fitted_params(model::HuberRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     scale     = fitresult.scale_,
     outliers  = fitresult.outliers_
     )
 add_human_name_trait(HuberRegressor, "Huber regressor")
+@sk_feature_importances HuberRegressor
 
 # =============================================================================
 const LarsRegressor_ = sklm(:Lars)
@@ -128,13 +133,14 @@ const LarsRegressor_ = sklm(:Lars)
     fit_path::Bool = true
 end
 MMI.fitted_params(model::LarsRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alphas    = fitresult.alphas_,
     active    = fitresult.active_,
     coef_path = fitresult.coef_path_
     )
 add_human_name_trait(LarsRegressor, "least angle regressor (LARS)")
+@sk_feature_importances LarsRegressor
 
 # =============================================================================
 const LarsCVRegressor_ = sklm(:LarsCV)
@@ -152,7 +158,7 @@ const LarsCVRegressor_ = sklm(:LarsCV)
     copy_X::Bool      = true
 end
 MMI.fitted_params(model::LarsCVRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
     alphas    = fitresult.alphas_,
@@ -161,6 +167,7 @@ MMI.fitted_params(model::LarsCVRegressor, (fitresult, _, _)) = (
     coef_path = fitresult.coef_path_
     )
 add_human_name_trait(LarsCVRegressor, "least angle regressor $CV")
+@sk_feature_importances LarsCVRegressor
 
 # =============================================================================
 const LassoRegressor_ = sklm(:Lasso)
@@ -177,9 +184,10 @@ const LassoRegressor_ = sklm(:Lasso)
     selection::String   = "cyclic"::(_ in ("cyclic","random"))
 end
 MMI.fitted_params(model::LassoRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     )
+@sk_feature_importances LassoRegressor
 
 # =============================================================================
 const LassoCVRegressor_ = sklm(:LassoCV)
@@ -200,7 +208,7 @@ const LassoCVRegressor_ = sklm(:LassoCV)
     selection::String   = "cyclic"::(_ in ("cyclic","random"))
 end
 MMI.fitted_params(model::LassoCVRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
     alphas    = fitresult.alphas_,
@@ -208,6 +216,7 @@ MMI.fitted_params(model::LassoCVRegressor, (fitresult, _, _)) = (
     dual_gap  = fitresult.dual_gap_
     )
 add_human_name_trait(LassoCVRegressor, "lasso regressor $CV")
+@sk_feature_importances LassoCVRegressor
 
 # =============================================================================
 const LassoLarsRegressor_ = sklm(:LassoLars)
@@ -225,13 +234,14 @@ const LassoLarsRegressor_ = sklm(:LassoLars)
     positive::Any       = false
 end
 MMI.fitted_params(model::LassoLarsRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alphas    = fitresult.alphas_,
     active    = fitresult.active_,
     coef_path = fitresult.coef_path_
     )
 add_human_name_trait(LassoLarsRegressor, "Lasso model fit with least angle regression (LARS)")
+@sk_feature_importances LassoLarsRegressor
 
 # =============================================================================
 const LassoLarsCVRegressor_ = sklm(:LassoLarsCV)
@@ -250,7 +260,7 @@ const LassoLarsCVRegressor_ = sklm(:LassoLarsCV)
     positive::Any       = false
 end
 MMI.fitted_params(model::LassoLarsCVRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     coef_path = fitresult.coef_path_,
     alpha     = fitresult.alpha_,
@@ -260,6 +270,7 @@ MMI.fitted_params(model::LassoLarsCVRegressor, (fitresult, _, _)) = (
     )
 add_human_name_trait(LassoLarsCVRegressor, "Lasso model fit with least angle "*
                      "regression (LARS) $CV")
+@sk_feature_importances LassoLarsCVRegressor
 
 # =============================================================================
 const LassoLarsICRegressor_ = sklm(:LassoLarsIC)
@@ -276,12 +287,13 @@ const LassoLarsICRegressor_ = sklm(:LassoLarsIC)
     positive::Any       = false
 end
 MMI.fitted_params(model::LassoLarsICRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_
     )
 add_human_name_trait(LassoLarsICRegressor, "Lasso model with LARS using "*
                      "BIC or AIC for model selection")
+@sk_feature_importances LassoLarsICRegressor
 
 # =============================================================================
 const LinearRegressor_ = sklm(:LinearRegression)
@@ -291,10 +303,11 @@ const LinearRegressor_ = sklm(:LinearRegression)
     n_jobs::Option{Int} = nothing
 end
 MMI.fitted_params(model::LinearRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
 add_human_name_trait(LinearRegressor, "ordinary least-squares regressor (OLS)")
+@sk_feature_importances LinearRegressor
 
 # =============================================================================
 const OrthogonalMatchingPursuitRegressor_ = sklm(:OrthogonalMatchingPursuit)
@@ -306,9 +319,10 @@ const OrthogonalMatchingPursuitRegressor_ = sklm(:OrthogonalMatchingPursuit)
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
 end
 MMI.fitted_params(model::OrthogonalMatchingPursuitRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
+@sk_feature_importances OrthogonalMatchingPursuitRegressor
 
 # =============================================================================
 const OrthogonalMatchingPursuitCVRegressor_ = sklm(:OrthogonalMatchingPursuitCV)
@@ -323,12 +337,13 @@ const OrthogonalMatchingPursuitCVRegressor_ = sklm(:OrthogonalMatchingPursuitCV)
     verbose::Union{Bool,Int} = false
 end
 MMI.fitted_params(model::OrthogonalMatchingPursuitCVRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     n_nonzero_coefs = fitresult.n_nonzero_coefs_
     )
 add_human_name_trait(OrthogonalMatchingPursuitCVRegressor, "orthogonal ,atching pursuit "*
                      "(OMP) model $CV")
+@sk_feature_importances OrthogonalMatchingPursuitCVRegressor
 
 # =============================================================================
 const PassiveAggressiveRegressor_ = sklm(:PassiveAggressiveRegressor)
@@ -349,9 +364,10 @@ const PassiveAggressiveRegressor_ = sklm(:PassiveAggressiveRegressor)
     average::Union{Bool,Int}     = false
 end
 MMI.fitted_params(model::PassiveAggressiveRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
+@sk_feature_importances PassiveAggressiveRegressor
 
 # =============================================================================
 const RANSACRegressor_ = sklm(:RANSACRegressor)
@@ -390,9 +406,10 @@ const RidgeRegressor_ = sklm(:Ridge)
     random_state::Any   = nothing
 end
 MMI.fitted_params(model::RidgeRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
+@sk_feature_importances RidgeRegressor
 
 # =============================================================================
 const RidgeCVRegressor_ = sklm(:RidgeCV)
@@ -405,12 +422,13 @@ const RidgeCVRegressor_ = sklm(:RidgeCV)
     store_cv_values::Bool    = false
 end
 MMI.fitted_params(model::RidgeCVRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
     cv_values = model.store_cv_values ? fitresult.cv_values_ : nothing
     )
 add_human_name_trait(RidgeCVRegressor, "ridge regressor $CV")
+@sk_feature_importances RidgeCVRegressor
 
 # =============================================================================
 const SGDRegressor_ = sklm(:SGDRegressor)
@@ -436,12 +454,13 @@ const SGDRegressor_ = sklm(:SGDRegressor)
     average::Union{Int,Bool} = false
 end
 MMI.fitted_params(model::SGDRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     average_coef      = model.average ? fitresult.average_coef_ : nothing,
     average_intercept = model.average ? ifelse(model.fit_intercept, fitresult.average_intercept_, nothing) : nothing
     )
 add_human_name_trait(SGDRegressor, "stochastic gradient descent-based regressor")
+@sk_feature_importances SGDRegressor
 
 # =============================================================================
 const TheilSenRegressor_ = sklm(:TheilSenRegressor)
@@ -457,13 +476,13 @@ const TheilSenRegressor_ = sklm(:TheilSenRegressor)
     verbose::Bool       = false
 end
 MMI.fitted_params(model::TheilSenRegressor, (fitresult, _, _)) = (
-    coef      = fitresult.coef_,
+    coef      = pyconvert(Array, fitresult.coef_),
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     breakdown       = fitresult.breakdown_,
     n_subpopulation = fitresult.n_subpopulation_
     )
 add_human_name_trait(TheilSenRegressor, "Theil-Sen regressor")
-
+@sk_feature_importances TheilSenRegressor
 
 # Metadata for Continuous -> Vector{Continuous}
 const SKL_REGS_SINGLE = Union{

--- a/src/models/linear-regressors.jl
+++ b/src/models/linear-regressors.jl
@@ -371,11 +371,11 @@ const RANSACRegressor_ = sklm(:RANSACRegressor)
 end
 MMI.fitted_params(m::RANSACRegressor, (f, _, _)) = (
     estimator             = f.estimator_,
-    n_trials              = f.n_trials_,
-    inlier_mask           = f.inlier_mask_,
-    n_skips_no_inliers    = f.n_skips_no_inliers_,
-    n_skips_invalid_data  = f.n_skips_invalid_data_,
-    n_skips_invalid_model = f.n_skips_invalid_model_
+    n_trials              = pyconvert(Int, f.n_trials_),
+    inlier_mask           = pyconvert(Array, f.inlier_mask_),
+    n_skips_no_inliers    = pyconvert(Int, f.n_skips_no_inliers_),
+    n_skips_invalid_data  = pyconvert(Int, f.n_skips_invalid_data_),
+    n_skips_invalid_model = pyconvert(Int, f.n_skips_invalid_model_)
     )
 
 # =============================================================================

--- a/src/models/misc.jl
+++ b/src/models/misc.jl
@@ -5,8 +5,8 @@ const DummyRegressor_ = skdu(:DummyRegressor)
     quantile::Float64 = 0.5::(0 ≤ _ ≤ 1)
 end
 MMI.fitted_params(m::DummyRegressor, (f, _, _)) = (
-    constant  = f.constant_,
-    n_outputs = f.n_outputs_
+    constant  = pyconvert(Array, f.constant_),
+    n_outputs = pyconvert(Int, f.n_outputs_)
     )
 meta(DummyRegressor,
     input   = Table(Continuous),
@@ -30,9 +30,9 @@ const DummyClassifier_ = skdu(:DummyClassifier)
     random_state::Any = nothing
 end
 MMI.fitted_params(m::DummyClassifier, (f, _, _)) = (
-    classes   = f.classes_,
-    n_classes = f.n_classes_,
-    n_outputs = f.n_outputs_
+    classes   = pyconvert(Array, f.classes_),
+    n_classes = pyconvert(Int, f.n_classes_),
+    n_outputs = pyconvert(Int, f.n_outputs_)
     )
 meta(DummyClassifier,
     input   = Table(Continuous),
@@ -55,11 +55,11 @@ const GaussianNBClassifier_ = sknb(:GaussianNB)
     var_smoothing::Float64                  = 1e-9::(_ > 0)
 end
 MMI.fitted_params(m::GaussianNBClassifier, (f, _, _)) = (
-    class_prior = f.class_prior_,
-    class_count = f.class_count_,
-    theta       = f.theta_,
-    var       = f.var_,
-    epsilon     = f.epsilon_,
+    class_prior = pyconvert(Array, f.class_prior_),
+    class_count = pyconvert(Array, f.class_count_),
+    theta       = pyconvert(Array, f.theta_),
+    var         = pyconvert(Array, f.var_),
+    epsilon     = pyconvert(Float64, f.epsilon_),
     )
 meta(GaussianNBClassifier,
     input   = Table(Continuous),
@@ -77,10 +77,10 @@ const BernoulliNBClassifier_ = sknb(:BernoulliNB)
     class_prior::Option{AbstractVector} = nothing::(_ === nothing || all(_ .≥ 0))
 end
 MMI.fitted_params(m::BernoulliNBClassifier, (f, _, _)) = (
-    class_log_prior  = f.class_log_prior_,
-    feature_log_prob = f.feature_log_prob_,
-    class_count      = f.class_count_,
-    feature_count    = f.feature_count_
+    class_log_prior  = pyconvert(Array, f.class_log_prior_),
+    feature_log_prob = pyconvert(Array, f.feature_log_prob_),
+    class_count      = pyconvert(Array, f.class_count_),
+    feature_count    = pyconvert(Array, f.feature_count_)
     )
 meta(BernoulliNBClassifier,
     input   = Table(Count),      # it expects binary but binarize takes care of that
@@ -108,10 +108,10 @@ const MultinomialNBClassifier_ = sknb(:MultinomialNB)
     class_prior::Option{AbstractVector} = nothing::(_ === nothing || all(_ .≥ 0))
 end
 MMI.fitted_params(m::MultinomialNBClassifier, (f, _, _)) = (
-    class_log_prior  = f.class_log_prior_,
-    feature_log_prob = f.feature_log_prob_,
-    class_count      = f.class_count_,
-    feature_count    = f.feature_count_
+    class_log_prior  = pyconvert(Array, f.class_log_prior_),
+    feature_log_prob = pyconvert(Array, f.feature_log_prob_),
+    class_count      = pyconvert(Array, f.class_count_),
+    feature_count    = pyconvert(Array, f.feature_count_)
     )
 meta(MultinomialNBClassifier,
     input   = Table(Count),        # NOTE: sklearn may also accept continuous (tf-idf)
@@ -138,18 +138,18 @@ const ComplementNBClassifier_ = sknb(:ComplementNB)
     norm::Bool      = false
 end
 MMI.fitted_params(m::ComplementNBClassifier, (f, _, _)) = (
-    class_log_prior  = f.class_log_prior_,
-    feature_log_prob = f.feature_log_prob_,
-    class_count      = f.class_count_,
-    feature_count    = f.feature_count_,
-    feature_all      = f.feature_all_
+    class_log_prior  = pyconvert(Array, f.class_log_prior_),
+    feature_log_prob = pyconvert(Array, f.feature_log_prob_),
+    class_count      = pyconvert(Array, f.class_count_),
+    feature_count    = pyconvert(Array, f.feature_count_),
+    feature_all      = pyconvert(Array, f.feature_all_)
     )
 meta(ComplementNBClassifier,
     input   = Table(Count),        # NOTE: sklearn may also accept continuous (tf-idf)
     target  = AbstractVector{<:Finite},
-     weights = false,
-     human_name = "Complement naive Bayes classifier"
-     )
+    weights = false,
+    human_name = "Complement naive Bayes classifier"
+    )
 
 """
 $(MMI.doc_header(ComplementNBClassifier))
@@ -196,10 +196,10 @@ const KNeighborsClassifier_ = skne(:KNeighborsClassifier)
     n_jobs::Option{Int} = nothing
 end
 MMI.fitted_params(m::KNeighborsClassifier, (f, _, _)) = (
-    classes                 = f.classes_,
+    classes                 = pyconvert(Array, f.classes_),
     effective_metric        = f.effective_metric_,
     effective_metric_params = f.effective_metric_params_,
-    outputs_2d              = f.outputs_2d_
+    outputs_2d              = pyconvert(Bool, f.outputs_2d_)
     )
 meta(KNeighborsClassifier,
     input   = Table(Continuous),

--- a/src/models/svm.jl
+++ b/src/models/svm.jl
@@ -59,7 +59,7 @@ meta(SVMClassifier,
 # ============================================================================
 const SVMLinearRegressor_ = sksv(:LinearSVR)
 @sk_reg mutable struct SVMLinearRegressor <: MMI.Deterministic
-    epsilon::Float64 = 0.0::(_ >= 0)
+    epsilon::Float64 = 0.0::(_ ≥ 0)
     tol::Float64     = 1e-4::(_ > 0)
     C::Float64       = 1.0::(_ > 0)
     loss::String      = "epsilon_insensitive"::(_ in ("epsilon_insensitive", "squared_epsilon_insensitive"))
@@ -89,7 +89,7 @@ const SVMRegressor_ = sksv(:SVR)
     coef0::Float64   = 0.0
     tol::Float64     = 1e-3::(_ > 0)
     C::Float64       = 1.0::(_ > 0)
-    epsilon::Float64 = 0.1::(_ >= 0)
+    epsilon::Float64 = 0.1::(_ ≥ 0)
     shrinking        = true
     cache_size::Int  = 200::(_ > 0)
     max_iter::Int    = -1

--- a/src/models/svm.jl
+++ b/src/models/svm.jl
@@ -22,7 +22,6 @@ meta(SVMLinearClassifier,
     target  = AbstractVector{<:Finite},
     human_name   = "linear support vector classifier"
     )
-@sk_feature_importances SVMLinearClassifier
 
 # ----------------------------------------------------------------------------
 const SVMClassifier_ = sksv(:SVC)

--- a/src/models/svm.jl
+++ b/src/models/svm.jl
@@ -12,10 +12,10 @@ const SVMLinearClassifier_ = sksv(:LinearSVC)
     max_iter::Int              = 1000::(_ > 0)
 end
 MMI.fitted_params(m::SVMLinearClassifier, (f, _, _)) = (
-    coef      = f.coef_,
-    intercept = f.intercept_,
-    classes   = f.classes_,
-    n_iter    = f.n_iter_
+    coef      = pyconvert(Array, f.coef_),
+    intercept = pyconvert(Array, f.intercept_),
+    classes   = pyconvert(Array, f.classes_),
+    n_iter    = pyconvert(Int, f.n_iter_)
     )
 meta(SVMLinearClassifier,
     input   = Table(Continuous),
@@ -39,14 +39,14 @@ const SVMClassifier_ = sksv(:SVC)
     random_state        = nothing
 end
 MMI.fitted_params(m::SVMClassifier, (f, _, _)) = (
-    support         = f.support_,
-    support_vectors = f.support_vectors_,
-    n_support       = f.n_support_,
-    dual_coef       = f.dual_coef_,
-    coef            = m.kernel == "linear" ? f.coef_ : nothing,
-    intercept       = f.intercept_,
-    fit_status      = f.fit_status_,
-    classes         = f.classes_
+    support         = pyconvert(Array, f.support_),
+    support_vectors = pyconvert(Array, f.support_vectors_),
+    n_support       = pyconvert(Array, f.n_support_),
+    dual_coef       = pyconvert(Array, f.dual_coef_),
+    coef            = m.kernel == "linear" ? pyconvert(Array, f.coef_) : nothing,
+    intercept       = pyconvert(Array, f.intercept_),
+    fit_status      = pyconvert(Int, f.fit_status_),
+    classes         = pyconvert(Array, f.classes_)
     # probA = f.probA_,
     # probB = f.probB_,
     )
@@ -70,9 +70,9 @@ const SVMLinearRegressor_ = sksv(:LinearSVR)
     max_iter::Int              = 1000::(_ > 0)
 end
 MMI.fitted_params(m::SVMLinearRegressor, (f, _, _)) = (
-    coef = f.coef_,
-    intercept = f.intercept_,
-    n_iter = f.n_iter_
+    coef = pyconvert(Array, f.coef_),
+    intercept = pyconvert(Array, f.intercept_),
+    n_iter = pyconvert(Int, f.n_iter_)
     )
 meta(SVMLinearRegressor,
     input   = Table(Continuous),
@@ -95,13 +95,13 @@ const SVMRegressor_ = sksv(:SVR)
     max_iter::Int    = -1
 end
 MMI.fitted_params(m::SVMRegressor, (f, _, _)) = (
-    support         = f.support_,
-    support_vectors = f.support_vectors_,
-    dual_coef       = f.dual_coef_,
-    coef            = m.kernel == "linear" ? f.coef_ : nothing,
-    intercept       = f.intercept_,
-    fit_status      = f.fit_status_,
-    n_iter          = f.n_iter_
+    support         = pyconvert(Array, f.support_),
+    support_vectors = pyconvert(Array, f.support_vectors_),
+    dual_coef       = pyconvert(Array, f.dual_coef_),
+    coef            = m.kernel == "linear" ? pyconvert(Array, f.coef_) : nothing,
+    intercept       = pyconvert(Array, f.intercept_),
+    fit_status      = pyconvert(Int, f.fit_status_),
+    n_iter          = pyconvert(Int, f.n_iter_)
     )
 meta(SVMRegressor,
     input   = Table(Continuous),
@@ -127,15 +127,15 @@ const SVMNuClassifier_ = sksv(:NuSVC)
     random_state        = nothing
 end
 MMI.fitted_params(m::SVMNuClassifier, (f, _, _)) = (
-    support         = f.support_,
-    support_vectors = f.support_vectors_,
-    n_support       = f.n_support_,
-    dual_coef       = f.dual_coef_,
-    coef            = m.kernel == "linear" ? f.coef_ : nothing,
-    intercept       = f.intercept_,
-    fit_status      = f.fit_status_,
-    classes         = f.classes_,
-    n_iter          = f.n_iter_
+    support         = pyconvert(Array, f.support_),
+    support_vectors = pyconvert(Array, f.support_vectors_),
+    n_support       = pyconvert(Array, f.n_support_),
+    dual_coef       = pyconvert(Array, f.dual_coef_),
+    coef            = m.kernel == "linear" ? pyconvert(Array, f.coef_) : nothing,
+    intercept       = pyconvert(Array, f.intercept_),
+    fit_status      = pyconvert(Int, f.fit_status_),
+    classes         = pyconvert(Array, f.classes_),
+    n_iter          = pyconvert(Int, f.n_iter_)
     # probA = f.probA_,
     # probB = f.probB_,
     )
@@ -160,12 +160,12 @@ const SVMNuRegressor_ = sksv(:NuSVR)
     max_iter::Int    = -1
 end
 MMI.fitted_params(m::SVMNuRegressor, (f, _, _)) = (
-    support         = f.support_,
-    support_vectors = f.support_vectors_,
-    dual_coef       = f.dual_coef_,
-    coef            = m.kernel == "linear" ? f.coef_ : nothing,
-    intercept       = f.intercept_,
-    n_iter          = f.n_iter_
+    support         = pyconvert(Array, f.support_),
+    support_vectors = pyconvert(Array, f.support_vectors_),
+    dual_coef       = pyconvert(Array, f.dual_coef_),
+    coef            = m.kernel == "linear" ? pyconvert(Array, f.coef_) : nothing,
+    intercept       = pyconvert(Array, f.intercept_),
+    n_iter          = pyconvert(Int, f.n_iter_)
     )
 meta(SVMNuRegressor,
     input   = Table(Continuous),

--- a/src/models/svm.jl
+++ b/src/models/svm.jl
@@ -22,6 +22,7 @@ meta(SVMLinearClassifier,
     target  = AbstractVector{<:Finite},
     human_name   = "linear support vector classifier"
     )
+@sk_feature_importances SVMLinearClassifier
 
 # ----------------------------------------------------------------------------
 const SVMClassifier_ = sksv(:SVC)
@@ -79,6 +80,7 @@ meta(SVMLinearRegressor,
     target  = AbstractVector{Continuous},
     human_name   = "linear support vector regressor"
     )
+@sk_feature_importances SVMLinearRegressor
 
 # ----------------------------------------------------------------------------
 const SVMRegressor_ = sksv(:SVR)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,0 +1,21 @@
+
+const ERR_TABLE_TYPE(t) = "Error: Expected a table or matrix of appropriate element types but got a data of type $t."
+
+function get_column_names(X)
+    Tables.istable(X) || throw((ERR_TABLE_TYPE(typeof(X))))
+    # Get the column names using Tables.columns or the first row
+    # Former is efficient for column tables, latter is efficient for row tables
+    if Tables.columnaccess(X)
+        columns = Tables.columns(X)
+        names = Tables.columnnames(columns)
+    else
+        iter = iterate(Tables.rows(X))
+        names = iter === nothing ? () : Tables.columnnames(first(iter))
+    end
+    return names
+end
+
+function get_column_names(X::AbstractMatrix)
+    n_cols = size(X, 2)
+    return Symbol.("x" .* string.(1:n_cols))
+end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,5 +1,7 @@
 
-const ERR_TABLE_TYPE(t) = "Error: Expected a table or matrix of appropriate element types but got a data of type $t."
+const ERR_TABLE_TYPE(t) = ArgumentError(
+    "Error: Expected a table or matrix of appropriate element types but got a data of type $t."
+)
 
 function get_column_names(X)
     Tables.istable(X) || throw((ERR_TABLE_TYPE(typeof(X))))

--- a/test/feature_importance_tests.jl
+++ b/test/feature_importance_tests.jl
@@ -1,0 +1,96 @@
+
+clf_models = (
+    # discriminant analysis
+    BayesianLDA,
+    
+    # ensemble classifiers
+    AdaBoostClassifier,
+    ExtraTreesClassifier,
+    GradientBoostingClassifier,
+    RandomForestClassifier,
+
+    # linear classifiers
+    LogisticClassifier,
+    LogisticCVClassifier,
+    PassiveAggressiveClassifier,
+    PerceptronClassifier,
+    RidgeClassifier,
+    RidgeCVClassifier,
+    SGDClassifier,
+
+    # svc
+    SVMLinearClassifier
+)
+
+@testset "Classification Feature Importance" begin
+    X, y = simple_binaryclf()
+    num_columns = length(Tables.columnnames(X))
+    for mod in clf_models
+        m = mod()
+        f, _, r = MB.fit(m, 1, X, y)
+        fi = MB.feature_importances(m, f, r)
+        @test size(fi) == (num_columns,)
+    end
+end
+
+reg_models = (
+    # ensemble regressors
+    AdaBoostRegressor,
+    ExtraTreesRegressor,
+    GradientBoostingRegressor,
+    RandomForestRegressor,
+
+    # linear regressors
+    ARDRegressor,
+    BayesianRidgeRegressor,
+    ElasticNetRegressor,
+    ElasticNetCVRegressor,
+    HuberRegressor,
+    LarsRegressor,
+    LarsCVRegressor,
+    LassoRegressor,
+    LassoCVRegressor,
+    LassoLarsRegressor,
+    LassoLarsCVRegressor,
+    LassoLarsICRegressor,
+    LinearRegressor,
+    OrthogonalMatchingPursuitRegressor,
+    OrthogonalMatchingPursuitCVRegressor,
+    PassiveAggressiveRegressor,
+    RidgeRegressor,
+    RidgeCVRegressor,
+    SGDRegressor,
+    TheilSenRegressor,
+
+    # srv
+    SVMLinearRegressor
+)
+
+@testset "Regression Feature Importance" begin
+    X, y = MB.make_regression()
+    num_columns = length(Tables.columnnames(X))
+    for mod in reg_models
+        m = mod()
+        f, _, r = MB.fit(m, 1, X, y)
+        fi = MB.feature_importances(m, f, r)
+        @test size(fi) == (num_columns,)
+    end
+end
+
+multi_reg_models = (
+    MultiTaskLassoRegressor,
+    MultiTaskLassoCVRegressor,
+    MultiTaskElasticNetRegressor,
+    MultiTaskElasticNetCVRegressor
+)
+
+@testset "Multi-Task Regression Feature Importance" begin
+    X, y, _ = simple_regression_2()
+    num_columns = size(X, 2)
+    for mod in multi_reg_models
+        m = mod()
+        f, _, r = MB.fit(m, 1, X, y)
+        fi = MB.feature_importances(m, f, r)
+        @test size(fi) == (num_columns,)
+    end
+end

--- a/test/feature_importance_tests.jl
+++ b/test/feature_importance_tests.jl
@@ -1,38 +1,4 @@
 
-clf_models = (
-    # discriminant analysis
-    BayesianLDA,
-    
-    # ensemble classifiers
-    AdaBoostClassifier,
-    ExtraTreesClassifier,
-    GradientBoostingClassifier,
-    RandomForestClassifier,
-
-    # linear classifiers
-    LogisticClassifier,
-    LogisticCVClassifier,
-    PassiveAggressiveClassifier,
-    PerceptronClassifier,
-    RidgeClassifier,
-    RidgeCVClassifier,
-    SGDClassifier,
-
-    # svc
-    SVMLinearClassifier
-)
-
-@testset "Classification Feature Importance" begin
-    X, y = simple_binaryclf()
-    num_columns = length(Tables.columnnames(X))
-    for mod in clf_models
-        m = mod()
-        f, _, r = MB.fit(m, 1, X, y)
-        fi = MB.feature_importances(m, f, r)
-        @test size(fi) == (num_columns,)
-    end
-end
-
 reg_models = (
     # ensemble regressors
     AdaBoostRegressor,

--- a/test/generic_api_tests.jl
+++ b/test/generic_api_tests.jl
@@ -44,7 +44,6 @@ bad_single_target_classifiers = [
     BayesianQDA,
     ProbabilisticSGDClassifier,
     SVMLinearClassifier,
-    SVMLinearClassifier,
     LogisticCVClassifier,
     LogisticClassifier,
     GaussianProcessClassifier,

--- a/test/models/clustering.jl
+++ b/test/models/clustering.jl
@@ -5,22 +5,33 @@ fparams = (
         AgglomerativeClustering = (:n_clusters, :labels, :n_leaves, :n_connected_components, :children),
         Birch = (:root, :dummy_leaf, :subcluster_centers, :subcluster_labels, :labels),
         DBSCAN = (:core_sample_indices,  :components, :labels),
+        HDBSCAN = (:labels,  :probabilities),
         FeatureAgglomeration = (:n_clusters, :labels, :n_leaves, :n_connected_components,  :children, :distances),
         KMeans = (:cluster_centers, :labels, :inertia),
+        BisectingKMeans = (:cluster_centers, :labels, :inertia),
         MiniBatchKMeans = (:cluster_centers, :labels, :inertia),
         MeanShift = (:cluster_centers, :labels),
         OPTICS = (:labels, :reachability, :ordering, :core_distances, :predecessor, :cluster_hierarchy),
-        SpectralClustering = (:labels, :affinity_matrix)
+        SpectralClustering = (:labels, :affinity_matrix),
+        # SpectralBiclustering = (:rows, :columns, :row_labels, :column_labels),
+        # SpectralCoclustering = (:rows, :columns, :row_labels, :column_labels, :biclusters),
     )
-
 
 models = (
         AffinityPropagation,
+        AgglomerativeClustering, 
         Birch,
-        AgglomerativeClustering,
-        Birch, 
         DBSCAN,
+        HDBSCAN,
+        FeatureAgglomeration,
         MeanShift,
+        KMeans,
+        BisectingKMeans,
+        MiniBatchKMeans,
+        MeanShift,
+        OPTICS,
+        # SpectralBiclustering,
+        # SpectralCoclustering
     )
 
 @testset "Fit/predict" begin

--- a/test/models/discriminant-analysis.jl
+++ b/test/models/discriminant-analysis.jl
@@ -4,7 +4,7 @@ models = (
     )
 
 fparams = (
-    BayesianLDA=(:coef, :intercept, :covariance, :means, :priors, :scalings, :xbar, :classes, :explained_variance_ratio),
+    BayesianLDA=(:coef, :intercept, :covariance, :explained_variance_ratio, :means, :priors, :scalings, :xbar, :classes),
     BayesianQDA=(:covariance, :means, :priors, :rotations, :scalings),
     )
 

--- a/test/models/ensemble.jl
+++ b/test/models/ensemble.jl
@@ -3,7 +3,8 @@ models = (
     BaggingClassifier,
     GradientBoostingClassifier,
     RandomForestClassifier,
-    ExtraTreesClassifier
+    ExtraTreesClassifier,
+    HistGradientBoostingClassifier
 )
 
 fparams = (
@@ -11,7 +12,8 @@ fparams = (
     BaggingClassifier=(:estimator, :estimators, :estimators_samples, :estimators_features, :classes, :n_classes, :oob_score, :oob_decision_function),
     GradientBoostingClassifier=(:n_estimators, :feature_importances, :train_score, :init, :estimators, :oob_improvement),
     RandomForestClassifier=(:estimator, :estimators, :classes, :n_classes, :n_features, :n_outputs, :feature_importances, :oob_score, :oob_decision_function),
-    ExtraTreesClassifier=(:estimator, :estimators, :classes, :n_classes, :feature_importances, :n_features, :n_outputs, :oob_score, :oob_decision_function)
+    ExtraTreesClassifier=(:estimator, :estimators, :classes, :n_classes, :feature_importances, :n_features, :n_outputs, :oob_score, :oob_decision_function),
+    HistGradientBoostingClassifier=(:classes, :do_early_stopping, :n_iter, :n_trees_per_iteration, :train_score, :validation_score)
 )
 
 @testset "Fit/Predict" begin
@@ -36,7 +38,8 @@ models = (
     BaggingRegressor,
     GradientBoostingRegressor,
     RandomForestRegressor,
-    ExtraTreesRegressor
+    ExtraTreesRegressor,
+    HistGradientBoostingRegressor,
 )
 
 fparams = (
@@ -44,7 +47,8 @@ fparams = (
     BaggingRegressor=(:estimator, :estimators, :estimators_samples, :estimators_features, :oob_score, :oob_prediction),
     GradientBoostingRegressor=(:feature_importances, :train_score, :init, :estimators, :oob_improvement),
     RandomForestRegressor=(:estimator, :estimators, :feature_importances, :n_features, :n_outputs, :oob_score, :oob_prediction),
-    ExtraTreesRegressor=(:estimator, :estimators, :feature_importances, :n_features, :n_outputs, :oob_score, :oob_prediction)
+    ExtraTreesRegressor=(:estimator, :estimators, :feature_importances, :n_features, :n_outputs, :oob_score, :oob_prediction),
+    HistGradientBoostingRegressor=(:do_early_stopping, :n_iter, :n_trees_per_iteration, :train_score, :validation_score)
 )
 
 @testset "Fit/Predict" begin

--- a/test/models/ensemble.jl
+++ b/test/models/ensemble.jl
@@ -8,7 +8,7 @@ models = (
 )
 
 fparams = (
-    AdaBoostClassifier=(:estimator, :estimators, :estimator_weights, :estimator_errors, :classes, :n_classes),
+    AdaBoostClassifier=(:estimator, :estimators, :estimator_weights, :estimator_errors, :classes, :n_classes, :feature_importances),
     BaggingClassifier=(:estimator, :estimators, :estimators_samples, :estimators_features, :classes, :n_classes, :oob_score, :oob_decision_function),
     GradientBoostingClassifier=(:n_estimators, :feature_importances, :train_score, :init, :estimators, :oob_improvement),
     RandomForestClassifier=(:estimator, :estimators, :classes, :n_classes, :n_features, :n_outputs, :feature_importances, :oob_score, :oob_decision_function),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ using MLJScikitLearnInterface
 using Test
 import MLJBase
 using PythonCall
-using StatisticalMeasures
 import MLJBase: target_scitype, input_scitype, output_scitype
 
 # Filter out warnings for convergence during testing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using MLJScikitLearnInterface
 using Test
 import MLJBase
 using PythonCall
+import Tables
 import MLJBase: target_scitype, input_scitype, output_scitype
 
 # Filter out warnings for convergence during testing
@@ -23,4 +24,6 @@ println("\ngaussian-process");        include("models/gaussian-process.jl")
 println("\nensemble");                include("models/ensemble.jl")
 println("\nclustering");              include("models/clustering.jl")
 
-println("\ngeneric interface tests");  include("generic_api_tests.jl")
+println("\nfeature importance tests");  include("feature_importance_tests.jl")
+println("\ngeneric interface tests");   include("generic_api_tests.jl")
+println("\nExtra tests from bug reports"); include("extras.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using MLJScikitLearnInterface
 using Test
 import MLJBase
 using PythonCall
+using StatisticalMeasures
 import MLJBase: target_scitype, input_scitype, output_scitype
 
 # Filter out warnings for convergence during testing

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -46,5 +46,5 @@ function test_clf(m, X, y)
     else
         ŷ = MB.predict_mode(m, f, X)
     end
-    return MB.accuracy(ŷ, y), f
+    return StatisticalMeasures.accuracy(ŷ, y), f
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -46,5 +46,5 @@ function test_clf(m, X, y)
     else
         ŷ = MB.predict_mode(m, f, X)
     end
-    return StatisticalMeasures.accuracy(ŷ, y), f
+    return sum(ŷ .== y)/length(y), f
 end


### PR DESCRIPTION
This PR does a couple of things:

Expand model support
- HDBSCAN
- BisectingKMeans 
- HistGradientBoostingRegressor  
- HistGradientBoostingClassifier 

Automatically convert more fitted params from Python back to Julia via `pyconvert`. 

Expand testing coverage for existing clustering models
- FeatureAgglomeration
- MeanShift
- KMeans
- BisectingKMeans
- MiniBatchKMeans

I also added support for seeing feature importances. It would be ideal to store the column names if a table was passed in, but I didn't want to add Tables.jl as a dependency. 

When running the tests, I noticed that MLJBase.jl upgrade to v1 broke the tests, so I fixed them by adding StatisticalMeasures.jl, and then restricted the MLJBase.jl compact. 