### PR TITLE
Fix classifiers that cannot handle only one target class

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJScikitLearnInterface"
 uuid = "5ae90465-5518-4432-b9d2-8a1def2f0cab"
 authors = ["Thibaut Lienart, Anthony Blaom"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -189,6 +189,9 @@ function _skmodel_fit_clf(modelname, params)
             yplain  = MMI.int(y)
 
             if size(unique(yplain), 1) == 1 # only one class (i46)
+                if verbosity > 0
+                    @warn "Model fitting skipped: Only one class present in the target data."
+                end
                 fitres = nothing
             else
                 # See _skmodel_fit_reg, same story

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -187,16 +187,21 @@ function _skmodel_fit_clf(modelname, params)
             Xmatrix = MMI.matrix(X)
             names = get_column_names(X)
             yplain  = MMI.int(y)
-            # See _skmodel_fit_reg, same story
-            sksym, skmod, mdl = $(Symbol(modelname, "_"))
-            parent = eval(sksym)
-            pyisnull(parent) && ski!(parent, skmod)
-            skconstr = getproperty(parent, mdl)
-            param_dict = Dict{Symbol, Any}(
-                [(p => _prepare_param(getfield(model, p))) for p in $params]
-            )
-            skmodel = skconstr(; param_dict...)
-            fitres  = SK.fit!(skmodel, Xmatrix, yplain)
+
+            if size(unique(yplain), 1) == 1 # only one class (i46)
+                fitres = nothing
+            else
+                # See _skmodel_fit_reg, same story
+                sksym, skmod, mdl = $(Symbol(modelname, "_"))
+                parent = eval(sksym)
+                pyisnull(parent) && ski!(parent, skmod)
+                skconstr = getproperty(parent, mdl)
+                param_dict = Dict{Symbol, Any}(
+                    [(p => _prepare_param(getfield(model, p))) for p in $params]
+                )
+                skmodel = skconstr(; param_dict...)
+                fitres  = SK.fit!(skmodel, Xmatrix, yplain)
+            end
             report = (; names)
             if ScikitLearnAPI.pyhasattr(fitres, "coef_")
                 column_std = std(Xmatrix, dims=1) |> vec
@@ -221,7 +226,13 @@ function _skmodel_predict(modelname)
     quote
         function MMI.predict(model::$modelname, (fitres, y1, targnames), Xnew)
             Xmatrix = MMI.matrix(Xnew)
-            preds   = SK.predict(fitres, Xmatrix)
+            if fitres === nothing
+                n = size(Xmatrix, 1)
+                preds = fill(y[1], n)
+            else
+                preds = SK.predict(fitres, Xmatrix)
+            end
+
             if isa(preds, Matrix)
                 # only regressors are possibly multitarget;
                 # build a table with the appropriate column names

--- a/test/extras.jl
+++ b/test/extras.jl
@@ -7,6 +7,30 @@
     @test f !== nothing
 end
 
+@testset "i48" begin
+    X, y = MB.make_blobs(500, 3, rng=555)
+    y[2:end] .= y[1]
+    models = [
+        PassiveAggressiveClassifier,
+        PerceptronClassifier,
+        SGDClassifier,
+        SVMClassifier,
+        SVMNuClassifier,
+        BayesianQDA,
+        ProbabilisticSGDClassifier,
+        SVMLinearClassifier,
+        LogisticCVClassifier,
+        LogisticClassifier,
+        GaussianProcessClassifier,
+        GradientBoostingClassifier
+    ]
+    for mod in models
+        m = mod()
+        f, = MB.fit(m, 1, X, y)
+        @test f !== nothing
+    end
+end
+
 @testset "i63" begin
     X, y = MB.make_blobs(500, 3, rng=555)
     w = Dict(1=>0.2, 2=>0.7, 3=>0.1)


### PR DESCRIPTION
Ref: https://github.com/JuliaAI/MLJScikitLearnInterface.jl/issues/48

Should we include a warning or any info tell the user that they are fitting a classifier with a single target class?

It looks like there are some registry issues with Julia right now. I will trigger the CI again when they have been resolved.