### PR TITLE
Update scikit learn to v1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
           - windows-latest
         arch:
           - x64
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,4 +1,4 @@
 
 [deps.scikit-learn]
 channel = "conda-forge"
-version = ">=1.2, <1.4"
+version = ">=1.4, <1.5"

--- a/src/models/clustering.jl
+++ b/src/models/clustering.jl
@@ -30,9 +30,7 @@ meta(AffinityPropagation,
 const AgglomerativeClustering_ = skcl(:AgglomerativeClustering)
 @sk_uns mutable struct AgglomerativeClustering <: MMI.Unsupervised
     n_clusters::Int     = 2::(_ ≥ 1)
-    # replace `affinity` parameter with `metric` when scikit learn releases v1.4
-    affinity::String    = "euclidean"::(_ in ("euclidean", "l1", "l2", "manhattan", "cosine", "precomputed"))
-    #metric::Any = nothing::(_ isa Union{Nothing, Function} || _ in ("euclidean", "l1", "l2", "manhattan", "cosine", "precomputed"))
+    metric::String      = "euclidean"::(_ in ("euclidean", "l1", "l2", "manhattan", "cosine", "precomputed"))
     memory::Any         = nothing
     connectivity::Any   = nothing
     compute_full_tree::Union{String,Bool} = "auto"::(_ isa Bool || _ == "auto")
@@ -187,8 +185,7 @@ const FeatureAgglomeration_ = skcl(:FeatureAgglomeration)
     connectivity::Any      = nothing
     # XXX unclear how to pass a proper callable here; just passing mean = nok
     # pooling_func::Function = mean
-    # replace `affinity` parameter with `metric` when scikit learn releases v1.4
-    affinity::Any          = "euclidean"::(_ isa Function || _ in ("euclidean", "l1", "l2", "manhattan", "cosine",  "precomputed"))
+    metric::Any            = "euclidean"::(_ isa Function || _ in ("euclidean", "l1", "l2", "manhattan", "cosine",  "precomputed"))
     compute_full_tree::Union{String,Bool} = "auto"::(_ isa Bool || _ == "auto")
     linkage::String        = "ward"::(_ in ("ward", "complete", "average", "single"))
     distance_threshold::Option{Float64}   = nothing

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -170,6 +170,9 @@ const ExtraTreesRegressor_ = sken(:ExtraTreesRegressor)
     random_state::Any              = nothing
     verbose::Int                   = 0
     warm_start::Bool               = false
+    ccp_alpha::Float64             = 0.0
+    max_samples::Option{Union{Int64,Float64,Nothing}} = nothing
+    monotonic_cst::Option{Union{Vector, Dict}} = nothing
 end
 @sk_feature_importances ExtraTreesRegressor
 MMI.fitted_params(m::ExtraTreesRegressor, (f, _, _)) = (
@@ -216,6 +219,9 @@ const ExtraTreesClassifier_ = sken(:ExtraTreesClassifier)
     verbose::Int                   = 0
     warm_start::Bool               = false
     class_weight::Any              = nothing
+    ccp_alpha::Float64             = 0.0
+    max_samples::Option{Union{Int64,Float64,Nothing}} = nothing
+    monotonic_cst::Option{Union{Vector, Dict}} = nothing
 end
 @sk_feature_importances ExtraTreesClassifier
 MMI.fitted_params(m::ExtraTreesClassifier, (f, _, _)) = (
@@ -367,6 +373,7 @@ const RandomForestRegressor_ = sken(:RandomForestRegressor)
     ccp_alpha::Float64             =0.0::(_ ≥ 0)
     max_samples::Union{Nothing,Float64,Int} =
         nothing::(_ === nothing || (_ ≥ 0 && (_ isa Integer || _ ≤ 1)))
+    monotonic_cst::Option{Union{Vector, Dict}} = nothing
 end
 @sk_feature_importances RandomForestRegressor
 MMI.fitted_params(model::RandomForestRegressor, (f, _, _)) = (
@@ -418,6 +425,7 @@ const RandomForestClassifier_ = sken(:RandomForestClassifier)
     ccp_alpha::Float64             =0.0::(_ ≥ 0)
     max_samples::Union{Nothing,Float64,Int} =
         nothing::(_ === nothing || (_ ≥ 0 && (_ isa Integer || _ ≤ 1)))
+    monotonic_cst::Option{Union{Vector, Dict}} = nothing
 end
 @sk_feature_importances RandomForestClassifier
 MMI.fitted_params(m::RandomForestClassifier, (f, _, _)) = (
@@ -463,7 +471,7 @@ const HistGradientBoostingRegressor_ = sken(:HistGradientBoostingRegressor)
     max_bins::Int                   = 255
     categorical_features::Option{Vector} = nothing
     monotonic_cst::Option{Union{Vector, Dict}} = nothing
-    # interaction_cst
+    interaction_cst::Any            = nothing
     warm_start::Bool                = false
     early_stopping::Union{String, Bool} = "auto"::(_ in ("auto", true, false))
     scoring::String                 = "loss"
@@ -507,7 +515,7 @@ const HistGradientBoostingClassifier_ = sken(:HistGradientBoostingClassifier)
     max_bins::Int                   = 255
     categorical_features::Option{Vector} = nothing
     monotonic_cst::Option{Union{Vector, Dict}} = nothing
-    # interaction_cst
+    interaction_cst::Any            = nothing
     warm_start::Bool                = false
     early_stopping::Union{String, Bool} = "auto"::(_ in ("auto",) || _ isa Bool)
     scoring::String                 = "loss"

--- a/src/models/linear-regressors.jl
+++ b/src/models/linear-regressors.jl
@@ -124,8 +124,6 @@ const LarsRegressor_ = sklm(:Lars)
 @sk_reg mutable struct LarsRegressor <: MMI.Deterministic
     fit_intercept::Bool      = true
     verbose::Union{Bool,Int} = false
-    # TODO Remove this when python ScikitLearn releases v1.4
-    normalize::Bool          = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     n_nonzero_coefs::Int     = 500::(_ > 0)
     eps::Float64   = eps(Float64)::(_ > 0)
@@ -148,8 +146,6 @@ const LarsCVRegressor_ = sklm(:LarsCV)
     fit_intercept::Bool      = true
     verbose::Union{Bool,Int} = false
     max_iter::Int     = 500::(_ > 0)
-    # TODO Remove this when python ScikitLearn releases v1.4
-    normalize::Bool   = false 
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     cv::Any           = 5
     max_n_alphas::Int = 1_000::(_ > 0)
@@ -224,8 +220,6 @@ const LassoLarsRegressor_ = sklm(:LassoLars)
     alpha::Float64      = 1.0::(_ ≥ 0) # 0 should be OLS
     fit_intercept::Bool = true
     verbose::Union{Bool, Int} = false
-    # TODO Remove this when python ScikitLearn releases v1.4
-    normalize::Bool     = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     max_iter::Int       = 500::(_ > 0)
     eps::Float64        = eps(Float64)::(_ > 0)
@@ -249,8 +243,6 @@ const LassoLarsCVRegressor_ = sklm(:LassoLarsCV)
     fit_intercept::Bool = true
     verbose::Union{Bool, Int} = false
     max_iter::Int       = 500::(_ > 0)
-    # TODO Remove this when python ScikitLearn releases v1.4
-    normalize::Bool     = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     cv::Any             = 5
     max_n_alphas::Int   = 1_000::(_ > 0)
@@ -278,8 +270,6 @@ const LassoLarsICRegressor_ = sklm(:LassoLarsIC)
     criterion::String   = "aic"::(_ in ("aic","bic"))
     fit_intercept::Bool = true
     verbose::Union{Bool, Int} = false
-    # TODO Remove this when python ScikitLearn releases v1.4
-    normalize::Bool     = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
     max_iter::Int       = 500::(_ > 0)
     eps::Float64        = eps(Float64)::(_ > 0.0)
@@ -315,7 +305,6 @@ const OrthogonalMatchingPursuitRegressor_ = sklm(:OrthogonalMatchingPursuit)
     n_nonzero_coefs::Option{Int} = nothing
     tol::Option{Float64} = nothing
     fit_intercept::Bool  = true
-    normalize::Bool      = false
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
 end
 MMI.fitted_params(model::OrthogonalMatchingPursuitRegressor, (fitresult, _, _)) = (
@@ -329,8 +318,6 @@ const OrthogonalMatchingPursuitCVRegressor_ = sklm(:OrthogonalMatchingPursuitCV)
 @sk_reg mutable struct OrthogonalMatchingPursuitCVRegressor <: MMI.Deterministic
     copy::Bool            = true
     fit_intercept::Bool   = true
-    # TODO Remove this when python ScikitLearn releases v1.4
-    normalize::Bool       = false
     max_iter::Option{Int} = nothing::(_ === nothing||_ > 0)
     cv::Any               = 5
     n_jobs::Option{Int}   = 1

--- a/src/models/linear-regressors.jl
+++ b/src/models/linear-regressors.jl
@@ -1,7 +1,6 @@
 const ARDRegressor_ = sklm(:ARDRegression)
 @sk_reg mutable struct ARDRegressor <: MMI.Deterministic
-    # TODO: rename `n_iter` to `max_iter` in v1.5
-    n_iter::Int               = 300::(_ > 0)
+    max_iter::Int             = 300::(_ > 0)
     tol::Float64              = 1e-3::(_ > 0)
     alpha_1::Float64          = 1e-6::(_ > 0)
     alpha_2::Float64          = 1e-6::(_ > 0)
@@ -19,7 +18,8 @@ MMI.fitted_params(model::ARDRegressor, (fitresult, _, _)) = (
     alpha     = fitresult.alpha_,
     lambda    = fitresult.lambda_,
     sigma     = fitresult.sigma_,
-    scores    = fitresult.scores_
+    scores    = fitresult.scores_,
+    n_iter    = fitresult.n_iter_,
     )
 add_human_name_trait(ARDRegressor, "Bayesian ARD regressor")
 @sk_feature_importances ARDRegressor
@@ -27,8 +27,7 @@ add_human_name_trait(ARDRegressor, "Bayesian ARD regressor")
 # =============================================================================
 const BayesianRidgeRegressor_ = sklm(:BayesianRidge)
 @sk_reg mutable struct BayesianRidgeRegressor <: MMI.Deterministic
-    # TODO: rename `n_iter` to `max_iter` in v1.5
-    n_iter::Int         = 300::(_ ≥ 1)
+    max_iter::Int       = 300::(_ ≥ 1)
     tol::Float64        = 1e-3::(_ > 0)
     alpha_1::Float64    = 1e-6::(_ > 0)
     alpha_2::Float64    = 1e-6::(_ > 0)
@@ -45,7 +44,8 @@ MMI.fitted_params(model::BayesianRidgeRegressor, (fitresult, _, _)) = (
     alpha     = fitresult.alpha_,
     lambda    = fitresult.lambda_,
     sigma     = fitresult.sigma_,
-    scores    = fitresult.scores_
+    scores    = fitresult.scores_,
+    n_iter    = fitresult.n_iter_,
     )
 add_human_name_trait(BayesianRidgeRegressor, "Bayesian ridge regressor")
 @sk_feature_importances BayesianRidgeRegressor

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1,12 +1,12 @@
 @testset "reg-mdl" begin
     m = ARDRegressor()
     @test m isa MB.Deterministic
-    @test m.n_iter > 0
+    @test m.max_iter > 0
     # set
-    m = ARDRegressor(n_iter=100)
-    @test m.n_iter == 100
+    m = ARDRegressor(max_iter=100)
+    @test m.max_iter == 100
     # clean method
-    @test @test_logs (:warn, r"Constraint") ARDRegressor(n_iter=-5).n_iter > 0
+    @test @test_logs (:warn, r"Constraint") ARDRegressor(max_iter=-5).max_iter > 0
 
     # traits
     @test MB.load_path(m) == "MLJScikitLearnInterface.ARDRegressor"

--- a/test/models/linear-regressors.jl
+++ b/test/models/linear-regressors.jl
@@ -23,8 +23,8 @@ models = (
     )
 
 fparams = (
-    ARDRegressor=(:coef, :intercept, :alpha, :lambda, :sigma, :scores),
-    BayesianRidgeRegressor=(:coef, :intercept, :alpha, :lambda, :sigma, :scores),
+    ARDRegressor=(:coef, :intercept, :alpha, :lambda, :sigma, :scores, :n_iter),
+    BayesianRidgeRegressor=(:coef, :intercept, :alpha, :lambda, :sigma, :scores, :n_iter),
     ElasticNetRegressor=(:coef, :intercept),
     ElasticNetCVRegressor=(:coef, :intercept, :l1_ratio, :mse_path, :alphas),
     HuberRegressor=(:coef, :intercept, :scale, :outliers),


### PR DESCRIPTION
This release had a few breaking changes and added `monotonic_cst` as a parameter on some ensemble models. I also removed the fully depreciated `normalize` parameter from all models. 

Since this will be a breaking release, I want to tackle updating some `Deterministic` models to `Probabilistic` (Ref https://github.com/JuliaAI/MLJScikitLearnInterface.jl/issues/47) before we tag it. 