### PR TITLE
Support Scikit-Learn v1.5, bump to v0.7 for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
     continue-on-error: ${{ matrix.version == 'nightly' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - name: "Replace julia libstdcxx ubuntu + julia v1.6"
         if: ${{ matrix.version == '1.6' && matrix.os == 'ubuntu-latest' }}
         # The following is needed for Julia <=1.8.3 on Linux OS 

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,4 +1,4 @@
 
 [deps.scikit-learn]
 channel = "conda-forge"
-version = ">=1.4, <1.5"
+version = ">=1.4, <1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJScikitLearnInterface"
 uuid = "5ae90465-5518-4432-b9d2-8a1def2f0cab"
 authors = ["Thibaut Lienart, Anthony Blaom"]
-version = "0.6.1"
+version = "0.7.0"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Repository implementing MLJ interface for
 [![Coverage](http://codecov.io/github/JuliaAI/MLJScikitLearnInterface.jl/coverage.svg?branch=master)](https://codecov.io/gh/JuliaAI/MLJScikitLearnInterface.jl)
 
 # Known Issue
-If you are using Linux and Julia version `>=1.8.3`, the `libstdcxx` version is not compatible with `scikit-learn>=1.2`. To get around this issue, you have to swap out the `libstdcxx` version that is loaded in with Julia. There is two methods to do this. The first is to build an environment with `Conda.jl` and use that as your `LD_LIBRARY_PATH`. 
+If you are using Linux and Julia version `<=1.8.3`, the `libstdcxx` version is not compatible with `scikit-learn>=1.2`. To get around this issue, you have to swap out the `libstdcxx` version that is loaded in with Julia. There is two methods to do this. The first is to build an environment with `Conda.jl` and use that as your `LD_LIBRARY_PATH`. 
 ```bash
 ROOT_ENV=`julia -e "using Conda; print(Conda.ROOTENV)"`
 export LD_LIBRARY_PATH=$ROOT_ENV"/lib":$LD_LIBRARY_PATH

--- a/src/models/ensemble.jl
+++ b/src/models/ensemble.jl
@@ -36,6 +36,7 @@ const AdaBoostClassifier_ = sken(:AdaBoostClassifier)
     estimator::Any    = nothing
     n_estimators::Int      = 50::(_ > 0)
     learning_rate::Float64 = 1.0::(_ > 0)
+    #TODO: Remove `SAMME.R` in v1.6
     algorithm::String      = "SAMME.R"::(_ in ("SAMME", "SAMME.R"))
     random_state::Any      = nothing
 end

--- a/src/models/linear-classifiers.jl
+++ b/src/models/linear-classifiers.jl
@@ -10,6 +10,7 @@ const LogisticClassifier_ = sklm(:LogisticRegression)
     random_state::Any          = nothing
     solver::String             = "lbfgs"::(_ in ("lbfgs", "newton-cg", "liblinear", "sag", "saga"))
     max_iter::Int              = 100::(_ > 0)
+    #TODO: Remove `multi_class` in v1.7+
     multi_class::String        = "auto"::(_ in ("ovr", "multinomial", "auto"))
     verbose::Int               = 0
     warm_start::Bool           = false
@@ -157,6 +158,7 @@ const RidgeCVClassifier_ = sklm(:RidgeClassifierCV)
     scoring::Any          = nothing
     cv::Int               = 5
     class_weight::Any     = nothing
+    #TODO: Use `store_cv_results` in v1.6+
     store_cv_values::Bool = false
 end
 MMI.fitted_params(m::RidgeCVClassifier, (f, _, _)) = (

--- a/src/models/linear-regressors.jl
+++ b/src/models/linear-regressors.jl
@@ -406,6 +406,7 @@ const RidgeCVRegressor_ = sklm(:RidgeCV)
     scoring::Any             = nothing
     cv::Any                  = 5
     gcv_mode::Option{String} = nothing::(_ === nothing || _ in ("auto","svd","eigen"))
+    #TODO: Use `store_cv_results` in v1.6+
     store_cv_values::Bool    = false
 end
 MMI.fitted_params(model::RidgeCVRegressor, (fitresult, _, _)) = (


### PR DESCRIPTION
[Scikit-learn v1.5 release highlights](https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_5_0.html)

v0.7 will support scikit-learn v1.4, 1.5. 

Scikit-learn v1.6, v1.7 will have more breaking changes. 